### PR TITLE
Compile fix for MSVC14

### DIFF
--- a/include/boost/type_traits/is_nothrow_move_assignable.hpp
+++ b/include/boost/type_traits/is_nothrow_move_assignable.hpp
@@ -16,6 +16,7 @@
 #include <boost/type_traits/has_nothrow_assign.hpp>
 #include <boost/type_traits/is_array.hpp>
 #include <boost/type_traits/is_reference.hpp>
+#include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/detail/ice_and.hpp>
 #include <boost/type_traits/detail/ice_or.hpp>
 #include <boost/type_traits/detail/ice_not.hpp>
@@ -37,7 +38,7 @@ struct false_or_cpp11_noexcept_move_assignable: public ::boost::false_type {};
 template <class T>
 struct false_or_cpp11_noexcept_move_assignable <
         T,
-        typename ::boost::enable_if_c<sizeof(T) && BOOST_NOEXCEPT_EXPR(::boost::declval<T&>() = ::boost::declval<T>())>::type
+        typename ::boost::enable_if_c<sizeof(T) && !::boost::is_const<T>::value && BOOST_NOEXCEPT_EXPR(::boost::declval<T&>() = ::boost::declval<T>())>::type
     > : public ::boost::integral_constant<bool, BOOST_NOEXCEPT_EXPR(::boost::declval<T&>() = ::boost::declval<T>())>
 {};
 


### PR DESCRIPTION
MSVC14 supports noexcept, but doesn't support expression SFINAE, so false_or_cpp11_noexcept_move_assignable<const T> fails to compile with
error C3892: 'boost::declval': you cannot assign to a variable that is const

Disabling the overload for const types so that they are never reported as noexcept move assignable fixes the compile error. Of course this doesn't work for imaginary UDTs with an assignment operator that is marked both noexcept and const - the alternative would be to guard the block with BOOST_NO_SFINAE_EXPR in addition to BOOST_NO_CXX11_NOEXCEPT.
