### PR TITLE
Correct spelling of "suppress"

### DIFF
--- a/test/is_copy_assignable.cpp
+++ b/test/is_copy_assignable.cpp
@@ -22,7 +22,7 @@ struct has {
 };
 
 // MSVC can not generate neither default constructor, nor assignment operator, 
-// nor copy constructor for `has2` type. Supressing those warnings is essential, 
+// nor copy constructor for `has2` type. Suppressing those warnings is essential, 
 // because we treat warnings as errors in those tests
 #if (defined _MSC_VER)
 # pragma warning( push )

--- a/test/is_copy_constructible_test.cpp
+++ b/test/is_copy_constructible_test.cpp
@@ -20,7 +20,7 @@ struct has {
 };
 
 // MSVC can not generate neither default constructor, nor assignment operator, 
-// nor copy constructor for `has2` type. Supressing those warnings is essential, 
+// nor copy constructor for `has2` type. Suppressing those warnings is essential, 
 // because we treat warnings as errors in those tests
 #if (defined _MSC_VER)
 # pragma warning( push )


### PR DESCRIPTION
"Suppress" is spelled with two P's, even in British English.