### PR TITLE
Add missing value_type typedef in integral_constant<bool> specialization

### DIFF
--- a/include/boost/type_traits/integral_constant.hpp
+++ b/include/boost/type_traits/integral_constant.hpp
@@ -77,6 +77,7 @@ namespace boost{
    struct integral_constant<bool, val>
    {
       typedef mpl::integral_c_tag tag;
+      typedef bool value_type;
       typedef integral_constant<bool, val> type;
       static const bool value = val;
       //


### PR DESCRIPTION
Retargets #16  towards `develop` instead of `master`.