### PR TITLE
First patch to support MSVC-7.1

### DIFF
--- a/include/boost/type_traits/detail/composite_pointer_type.hpp
+++ b/include/boost/type_traits/detail/composite_pointer_type.hpp
@@ -128,13 +128,15 @@ public:
 
 template<class T, class U> struct composite_pointer_type<T*, U*>
 {
+    //Done in two steps to avoid compilation errors
+    //in old compilers like MSVC 7.1
     typedef typename boost::conditional<
 
         detail::has_common_pointee<T, U>::value,
         detail::common_pointee<T, U>,
         detail::composite_pointer_impl<T, U>
-
-    >::type::type * type;
+    >::type first_type;
+    typename first_type::type * type;
 };
 
 } // namespace type_traits_detail

--- a/include/boost/type_traits/detail/has_binary_operator.hpp
+++ b/include/boost/type_traits/detail/has_binary_operator.hpp
@@ -37,7 +37,10 @@
 #   pragma GCC system_header
 #elif defined(BOOST_MSVC)
 #   pragma warning ( push )
-#   pragma warning ( disable : 4018 4244 4547 4800 4804 4805 4913 6334)
+#   pragma warning ( disable : 4018 4244 4547 4800 4804 4805 4913)
+#   if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
+#       pragma warning ( disable : 6334)
+#   endif
 #endif
 
 namespace boost {

--- a/include/boost/type_traits/detail/has_postfix_operator.hpp
+++ b/include/boost/type_traits/detail/has_postfix_operator.hpp
@@ -23,7 +23,10 @@
 #   pragma GCC system_header
 #elif defined(BOOST_MSVC)
 #   pragma warning ( push )
-#   pragma warning ( disable : 4244 4913 6334)
+#   pragma warning ( disable : 4244 4913)
+#   if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
+#       pragma warning ( disable : 6334)
+#   endif
 #endif
 
 namespace boost {

--- a/include/boost/type_traits/detail/has_prefix_operator.hpp
+++ b/include/boost/type_traits/detail/has_prefix_operator.hpp
@@ -31,8 +31,13 @@
 #   pragma GCC system_header
 #elif defined(BOOST_MSVC)
 #   pragma warning ( push )
-#   pragma warning ( disable : 4146 4804 4913 4244 6334)
+#   pragma warning ( disable : 4146 4804 4913 4244)
+#   if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
+#       pragma warning ( disable : 6334)
+#   endif
 #endif
+
+
 
 namespace boost {
 namespace detail {

--- a/include/boost/type_traits/is_signed.hpp
+++ b/include/boost/type_traits/is_signed.hpp
@@ -19,7 +19,9 @@ namespace boost {
 
 #if !defined( __CODEGEARC__ )
 
-#if !(defined(__EDG_VERSION__) && __EDG_VERSION__ <= 238) && !defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION)
+#if !(defined(BOOST_MSVC) && BOOST_MSVC <= 1310) && \
+    !(defined(__EDG_VERSION__) && __EDG_VERSION__ <= 238) &&\
+    !defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION)
 
 namespace detail{
 

--- a/include/boost/type_traits/is_unsigned.hpp
+++ b/include/boost/type_traits/is_unsigned.hpp
@@ -20,7 +20,9 @@ namespace boost {
 
 #if !defined( __CODEGEARC__ )
 
-#if !(defined(__EDG_VERSION__) && __EDG_VERSION__ <= 238) && !defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION)
+#if !(defined(BOOST_MSVC) && BOOST_MSVC <= 1310) &&\
+    !(defined(__EDG_VERSION__) && __EDG_VERSION__ <= 238) &&\
+    !defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION)
 
 namespace detail{
 


### PR DESCRIPTION
Trivial patches to support MSVC-7.1. After these, only common_type related two tests fail, a problem that requires more time and an additional patch. Information about the patch:

-> MSVC7-1 does not support warnings above 4999. This problem was already workarounded in some files  using BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000), which is what I've done.
-> composite_pointer_type requires two steps to form a pointer, so that MSVC-7.1 can correctly handle it.