### PR TITLE
Change check to s_check (like #8542)

### DIFF
--- a/include/boost/type_traits/detail/mp_defer.hpp
+++ b/include/boost/type_traits/detail/mp_defer.hpp
@@ -25,12 +25,12 @@ template<template<class...> class F, class... T>
 struct mp_valid_impl
 {
     template<template<class...> class G, class = G<T...>>
-    static boost::true_type check(int);
+    static boost::true_type check_s(int);
 
     template<template<class...> class>
-    static boost::false_type check(...);
+    static boost::false_type check_s(...);
 
-    using type = decltype(check<F>(0));
+    using type = decltype(check_s<F>(0));
 };
 
 template<template<class...> class F, class... T>


### PR DESCRIPTION
Rename check to s_check so that OSX AssertMacros.h cannot mess it up.