### PR TITLE
Fixes for clang in MSVC mode

### DIFF
--- a/include/boost/type_traits/has_nothrow_assign.hpp
+++ b/include/boost/type_traits/has_nothrow_assign.hpp
@@ -24,7 +24,7 @@
 #include <boost/type_traits/remove_reference.hpp>
 #endif
 #endif
-#if defined(__GNUC__) || defined(__SUNPRO_CC)
+#if defined(__GNUC__) || defined(__SUNPRO_CC) || defined(__clang__)
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_volatile.hpp>
 #include <boost/type_traits/is_assignable.hpp>

--- a/include/boost/type_traits/has_nothrow_constructor.hpp
+++ b/include/boost/type_traits/has_nothrow_constructor.hpp
@@ -17,7 +17,7 @@
 #if defined(BOOST_MSVC) || defined(BOOST_INTEL)
 #include <boost/type_traits/has_trivial_constructor.hpp>
 #endif
-#if defined(__GNUC__ ) || defined(__SUNPRO_CC)
+#if defined(__GNUC__ ) || defined(__SUNPRO_CC) || defined(__clang__)
 #include <boost/type_traits/is_default_constructible.hpp>
 #endif
 

--- a/include/boost/type_traits/has_trivial_assign.hpp
+++ b/include/boost/type_traits/has_trivial_assign.hpp
@@ -13,7 +13,7 @@
 #include <boost/type_traits/intrinsics.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 
-#if !defined(BOOST_HAS_TRIVIAL_ASSIGN) || defined(BOOST_MSVC) || defined(__GNUC__) || defined(BOOST_INTEL) || defined(__SUNPRO_CC) || defined(__clang)
+#if !defined(BOOST_HAS_TRIVIAL_ASSIGN) || defined(BOOST_MSVC) || defined(__GNUC__) || defined(BOOST_INTEL) || defined(__SUNPRO_CC) || defined(__clang__)
 #include <boost/type_traits/is_pod.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_volatile.hpp>

--- a/include/boost/type_traits/has_trivial_destructor.hpp
+++ b/include/boost/type_traits/has_trivial_destructor.hpp
@@ -21,7 +21,7 @@
 #include <boost/type_traits/is_same.hpp>
 #endif
 
-#if defined(__GNUC__) || defined(__clang) || defined(__SUNPRO_CC)
+#if defined(__GNUC__) || defined(__clang__) || defined(__SUNPRO_CC)
 #include <boost/type_traits/is_destructible.hpp>
 #endif
 


### PR DESCRIPTION
In MSVC mode, clang doesn't define `__GNUC__`.
Also, it doesn't define `__clang`, but defines `__clang__`.