### PR TITLE
Fix compilation error with MSC+Clang

### DIFF
--- a/include/boost/type_traits/has_nothrow_assign.hpp
+++ b/include/boost/type_traits/has_nothrow_assign.hpp
@@ -24,7 +24,7 @@
 #include <boost/type_traits/remove_reference.hpp>
 #endif
 #endif
-#if defined(__GNUC__) || defined(__SUNPRO_CC)
+#if defined(__GNUC__) || defined(BOOST_CLANG) || defined(__SUNPRO_CC)
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_volatile.hpp>
 #include <boost/type_traits/is_assignable.hpp>

--- a/include/boost/type_traits/has_nothrow_constructor.hpp
+++ b/include/boost/type_traits/has_nothrow_constructor.hpp
@@ -17,7 +17,7 @@
 #if defined(BOOST_MSVC) || defined(BOOST_INTEL)
 #include <boost/type_traits/has_trivial_constructor.hpp>
 #endif
-#if defined(__GNUC__ ) || defined(__SUNPRO_CC)
+#if defined(__GNUC__ ) || defined(BOOST_CLANG) || defined(__SUNPRO_CC)
 #include <boost/type_traits/is_default_constructible.hpp>
 #endif
 


### PR DESCRIPTION
Check `defined(BOOST_CLANG)` explicitly.