### PR TITLE
Add make_void and void_t traits

### DIFF
--- a/doc/make_void.qbk
+++ b/doc/make_void.qbk
@@ -1,0 +1,47 @@
+[/
+Copyright 2017 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software License,
+Version 1.0. (See accompanying file LICENSE_1_0.txt
+or copy at http://www.boost.org/LICENSE_1_0.txt).
+]
+
+[section:make_void make_void]
+
+    template<class...>
+    struct make_void
+    {
+        typedef void type;
+    };
+
+    template<class... Ts>
+    using void_t = typename make_void<Ts...>::type;
+
+__type The type `void` for all `T`.
+
+__header ` #include <boost/type_traits/make_void.hpp>` or ` #include <boost/type_traits.hpp>`
+
+[table Examples
+
+[[Expression] [Result Type]]
+
+[[`make_void<int>::type`][`void`]]
+
+[[`make_void<int&>::type`] [`void`]]
+
+[[`make_void<int(*)(int)>::type`] [`void`]]
+
+[[`make_void<int[]>::type`] [`void`]]
+
+[[`make_void<int[1]>::type`] [`void`]]
+
+[[`make_void<>::type`] [`void`]]
+
+[[`make_void<int, int>::type`] [`void`]]
+
+]
+
+[all_compilers]
+
+[endsect]

--- a/doc/type_traits.qbk
+++ b/doc/type_traits.qbk
@@ -134,6 +134,7 @@
 
 [def __make_signed [link boost_typetraits.reference.make_signed make_signed]]
 [def __make_unsigned [link boost_typetraits.reference.make_unsigned make_unsigned]]
+[def __make_void [link boost_typetraits.reference.make_void make_void]]
 [def __decay [link boost_typetraits.reference.decay decay]]
 [def __is_complex [link boost_typetraits.reference.is_complex is_complex]]
 
@@ -316,6 +317,7 @@ See __has_trivial_constructor.
 
 [include make_signed.qbk]
 [include make_unsigned.qbk]
+[include make_void.qbk]
 
 [include promote.qbk]
 [include rank.qbk]

--- a/include/boost/type_traits.hpp
+++ b/include/boost/type_traits.hpp
@@ -130,6 +130,7 @@
 #include <boost/type_traits/is_volatile.hpp>
 #include <boost/type_traits/make_signed.hpp>
 #include <boost/type_traits/make_unsigned.hpp>
+#include <boost/type_traits/make_void.hpp>
 #include <boost/type_traits/rank.hpp>
 #include <boost/type_traits/remove_all_extents.hpp>
 #include <boost/type_traits/remove_bounds.hpp>

--- a/include/boost/type_traits/make_void.hpp
+++ b/include/boost/type_traits/make_void.hpp
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software License,
+Version 1.0. (See accompanying file LICENSE_1_0.txt
+or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_TT_MAKE_VOID_HPP_INCLUDED
+#define BOOST_TT_MAKE_VOID_HPP_INCLUDED
+
+#include <boost/config.hpp>
+
+namespace boost {
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+template<class...>
+struct make_void {
+    typedef void type;
+};
+
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+template<class... Ts>
+using void_t = typename make_void<Ts...>::type;
+#endif
+#else
+template<class>
+struct make_void {
+    typedef void type;
+};
+
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+template<class T>
+using void_t = typename make_void<T>::type;
+#endif
+#endif
+
+} /* boost */
+
+#endif

--- a/test/make_void_test.cpp
+++ b/test/make_void_test.cpp
@@ -1,0 +1,34 @@
+/*
+Copyright 2017 Glen Joseph Fernandes
+<glenjofe -at- gmail.com>
+
+Distributed under the Boost Software License,
+Version 1.0. (See accompanying file LICENSE_1_0.txt
+or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#include "test.hpp"
+#include "check_type.hpp"
+
+#ifdef TEST_STD
+#include <type_traits>
+#else
+#include <boost/type_traits/make_void.hpp>
+#endif
+
+TT_TEST_BEGIN(make_void)
+
+BOOST_CHECK_TYPE(::tt::make_void<int>::type, void);
+BOOST_CHECK_TYPE(::tt::make_void<const volatile int>::type, void);
+BOOST_CHECK_TYPE(::tt::make_void<int&>::type, void);
+BOOST_CHECK_TYPE(::tt::make_void<void>::type, void);
+BOOST_CHECK_TYPE(::tt::make_void<int(*)(int)>::type, void);
+BOOST_CHECK_TYPE(::tt::make_void<int[]>::type, void);
+BOOST_CHECK_TYPE(::tt::make_void<int[1]>::type, void);
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+BOOST_CHECK_TYPE(::tt::make_void<>::type, void);
+BOOST_CHECK_TYPE3(::tt::make_void<int, int>::type, void);
+#endif
+
+TT_TEST_END


### PR DESCRIPTION
C++17 added `std::void_t` and this provides `boost::void_t` and `boost::make_void`, which are commonly used in `decltype` SFINAE expressions.