### PR TITLE
Add multiple type support to pre-C++11 void_t alias

### DIFF
--- a/include/boost/type_traits/make_void.hpp
+++ b/include/boost/type_traits/make_void.hpp
@@ -25,16 +25,24 @@ template<class... Ts>
 using void_t = typename make_void<Ts...>::type;
 #endif
 
-#else // BOOST_NO_CXX11_VARIADIC_TEMPLATES
+#else /* BOOST_NO_CXX11_VARIADIC_TEMPLATES */
 
-template<class T = void, class U = void, class V = void, class X = void, class Y = void>
+template<class = void,
+         class = void,
+         class = void,
+         class = void,
+         class = void>
 struct make_void {
     typedef void type;
 };
 
 #if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
-template<class T>
-using void_t = typename make_void<T>::type;
+template<class A = void,
+         class B = void,
+         class C = void,
+         class D = void,
+         class E = void>
+using void_t = typename make_void<A, B, C, D, E>::type;
 #endif
 
 #endif


### PR DESCRIPTION
In the absence of variadic templates but with template aliases, void_t should also support up to five parameter types.