### PR TITLE
Make is_virtual_base_of work on final classes

### DIFF
--- a/include/boost/type_traits/is_virtual_base_of.hpp
+++ b/include/boost/type_traits/is_virtual_base_of.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright Daniel Frey and Robert Ramey 2009.
+//  (C) Copyright Balint Cserni 2017
 //  Use, modification and distribution are subject to the Boost Software License,
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt).
@@ -9,7 +10,6 @@
 #define BOOST_TT_IS_VIRTUAL_BASE_OF_HPP_INCLUDED
 
 #include <boost/type_traits/is_base_of.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 namespace boost {
 namespace detail {
@@ -22,70 +22,34 @@ namespace detail {
 #pragma GCC system_header
 #endif
 
-template<typename Base, typename Derived, typename tag>
+template<class Base, class Derived>
 struct is_virtual_base_of_impl
 {
-    BOOST_STATIC_CONSTANT(bool, value = false);
-};
+	template<class From, class To>
+	struct can_cast
+	{
+		typedef char YES;
+		typedef struct { char x[2]; } NO;
 
-template<typename Base, typename Derived>
-struct is_virtual_base_of_impl<Base, Derived, true_type>
-{
-   union max_align
-   {
-      unsigned u;
-      unsigned long ul;
-      void* v;
-      double d;
-      long double ld;
-#ifndef BOOST_NO_LONG_LONG
-      long long ll;
-#endif
-   };
-#ifdef __BORLANDC__
-    struct boost_type_traits_internal_struct_X : public virtual Derived, public virtual Base 
-    {
-       boost_type_traits_internal_struct_X();
-       boost_type_traits_internal_struct_X(const boost_type_traits_internal_struct_X&);
-       boost_type_traits_internal_struct_X& operator=(const boost_type_traits_internal_struct_X&);
-       ~boost_type_traits_internal_struct_X()throw();
-       max_align data[4];
-    };
-    struct boost_type_traits_internal_struct_Y : public virtual Derived 
-    {
-       boost_type_traits_internal_struct_Y();
-       boost_type_traits_internal_struct_Y(const boost_type_traits_internal_struct_Y&);
-       boost_type_traits_internal_struct_Y& operator=(const boost_type_traits_internal_struct_Y&);
-       ~boost_type_traits_internal_struct_Y()throw();
-       max_align data[4];
-    };
-#else
-    struct boost_type_traits_internal_struct_X : public Derived, virtual Base 
-    {
-       boost_type_traits_internal_struct_X();
-       boost_type_traits_internal_struct_X(const boost_type_traits_internal_struct_X&);
-       boost_type_traits_internal_struct_X& operator=(const boost_type_traits_internal_struct_X&);
-       ~boost_type_traits_internal_struct_X()throw();
-       max_align data[16];
-    };
-    struct boost_type_traits_internal_struct_Y : public Derived 
-    {
-       boost_type_traits_internal_struct_Y();
-       boost_type_traits_internal_struct_Y(const boost_type_traits_internal_struct_Y&);
-       boost_type_traits_internal_struct_Y& operator=(const boost_type_traits_internal_struct_Y&);
-       ~boost_type_traits_internal_struct_Y()throw();
-       max_align data[16];
-    };
-#endif
-    BOOST_STATIC_CONSTANT(bool, value = (sizeof(boost_type_traits_internal_struct_X)==sizeof(boost_type_traits_internal_struct_Y)));
-};
+		// C-style casts have the power to ignore inheritance visibility while still act as a static_cast.
+		// They can also fall back to the behaviour of reinterpret_cast, which allows is_virtual_base_of to work on non-class types too.
+		// Note that because we are casting pointers there can be no user-defined operators to interfere.
+		template<unsigned = sizeof((To*)((From*)(0)))> static YES test(int*);
+		static NO test(...);
 
-template<typename Base, typename Derived>
-struct is_virtual_base_of_impl2
-{
-   typedef boost::integral_constant<bool, (boost::is_base_of<Base, Derived>::value && ! boost::is_same<Base, Derived>::value)> tag_type;
-   typedef is_virtual_base_of_impl<Base, Derived, tag_type> imp;
-   BOOST_STATIC_CONSTANT(bool, value = imp::value);
+		BOOST_STATIC_CONSTANT(bool, value = (sizeof(test(nullptr)) == sizeof(YES)));
+	};
+
+	// Implementation based on the standard's rules of explicit type conversions.
+	// A pointer to an object of *derived* class type may be explicitly converted to a pointer to an *unambiguous* *base* class type.
+	// A pointer to an object of an *unambiguous* *non-virtual* *base* class type may be explicitly converted to a pointer of a *derived* class type.
+	// Therefore Derived has a virtual base Base if and only if
+	//   (1) a Derived* can be converted to Base* (so the base class is unambiguous, which comes necessarily from virtual inheritance)
+	//   (2) a Base* cannot be converted to Derived* (so the base class is either ambiguous or virtual)
+	// With both conditions true, Base must be a virtual base of Derived.
+	// The "is_base_of" is only needed so the compiler can (but is not required to) error out if the types are incomplete.
+	// This is in league with the the expected behaviour.
+	BOOST_STATIC_CONSTANT(bool, value = (boost::is_base_of<Base, Derived>::value && can_cast<Derived, Base>::value && !can_cast<Base, Derived>::value));
 };
 
 #ifdef BOOST_MSVC
@@ -94,7 +58,7 @@ struct is_virtual_base_of_impl2
 
 } // namespace detail
 
-template <class Base, class Derived> struct is_virtual_base_of : public integral_constant<bool, (::boost::detail::is_virtual_base_of_impl2<Base, Derived>::value)>{};
+template <class Base, class Derived> struct is_virtual_base_of : public integral_constant<bool, (::boost::detail::is_virtual_base_of_impl<Base, Derived>::value)>{};
 
 template <class Base, class Derived> struct is_virtual_base_of<Base&, Derived> : public false_type{};
 template <class Base, class Derived> struct is_virtual_base_of<Base, Derived&> : public false_type{};


### PR DESCRIPTION
The current `boost::is_virtual_base_of<Base, Derived>` metaprogram uses inheritance and size comparision when finding out whether `Base` is a virtual base of `Derived`. This however fails to compile if `Derived` is defined final.

This redesign of `boost::is_virtual_base_of` uses the standard's rules of pointer to pointer conversion to determine the output, which also works on final classes and is less dependant on specific compiler implementations.