### PR TITLE
Add C++14-style _t aliases

### DIFF
--- a/doc/add_const.qbk
+++ b/doc/add_const.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using add_const_t = typename add_const<T>::type; // C++11 and above
+
 __type The same type as `T const` for all `T`.  
 
 __std_ref 3.9.3.

--- a/doc/add_cv.qbk
+++ b/doc/add_cv.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using add_cv_t = typename add_cv<T>::type; // C++11 and above
+
 __type The same type as `T const volatile` for all `T`.  
 
 __std_ref 3.9.3.

--- a/doc/add_lvalue_reference.qbk
+++ b/doc/add_lvalue_reference.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using add_lvalue_reference_t = typename add_lvalue_reference<T>::type; // C++11 and above
+
 __type If `T` names an object or function type then the member typedef `type`
 shall name `T&`; otherwise, if `T` names a type ['rvalue reference to U] then
 the member typedef type shall name `U&`; otherwise, type shall name `T`.

--- a/doc/add_pointer.qbk
+++ b/doc/add_pointer.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using add_pointer_t = typename add_pointer<T>::type; // C++11 and above
+
 __type The same type as `remove_reference<T>::type*`.  
 
 The rationale for this template

--- a/doc/add_rvalue_reference.qbk
+++ b/doc/add_rvalue_reference.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using add_rvalue_reference_t = typename add_rvalue_reference<T>::type; // C++11 and above
+
 __type If `T` names an object or function type then the member typedef type
 shall name `T&&`; otherwise, type shall name `T`. ['\[Note: This rule reflects
 the semantics of reference collapsing. For example, when a type `T` names

--- a/doc/add_volatile.qbk
+++ b/doc/add_volatile.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using add_volatile_t = typename add_volatile<T>::type; // C++11 and above
+
 __type The same type as `T volatile` for all `T`.  
 
 __std_ref 3.9.3.

--- a/doc/common_type.qbk
+++ b/doc/common_type.qbk
@@ -15,6 +15,7 @@ __header ` #include <boost/type_traits/common_type.hpp>` or ` #include <boost/ty
 
     namespace boost {
       template <class... T> struct common_type;
+      template<class... T> using common_type_t = typename common_type<T...>::type; // C++11 and above
     }
 
 

--- a/doc/conditional.qbk
+++ b/doc/conditional.qbk
@@ -14,6 +14,7 @@ __header ` #include <boost/type_traits/conditional.hpp>` or ` #include <boost/ty
 
     namespace boost {
       template <bool B, class T, class U>  struct __conditional;
+      template <bool B, class T, class U>  using conditional_t = typename conditional<B, T, U>::type; // C++11 and above
     }
 
 If B is true, the member typedef type shall equal T. If B is false, the member typedef type shall equal U.

--- a/doc/copy_cv.qbk
+++ b/doc/copy_cv.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T, class U> using copy_cv_t = typename copy_cv<T, U>::type; // C++11 and above
+
 __type [^T /cv/], where /cv/ are the cv-qualifiers of `U`.
 
 __header ` #include <boost/type_traits/copy_cv.hpp>` or ` #include <boost/type_traits.hpp>`

--- a/doc/decay.qbk
+++ b/doc/decay.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using decay_t = typename decay<T>::type; // C++11 and above
+
 __type Let `U` be the result of `remove_reference<T>::type`, then if `U` is
 an array type, the result is `remove_extent<U>::type*`, otherwise if `U` is a 
 function type then the result is `U*`, otherwise the result is `U`.

--- a/doc/floating_point_promotion.qbk
+++ b/doc/floating_point_promotion.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using floating_point_promotion_t = typename floating_point_promotion<T>::type; // C++11 and above
+
 __type If floating point promotion can be applied to an rvalue of type `T`,
 then applies floating point promotion to `T` and keeps cv-qualifiers of `T`,
 otherwise leaves `T` unchanged.

--- a/doc/integral_promotion.qbk
+++ b/doc/integral_promotion.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using integral_promotion_t = typename integral_promotion<T>::type; // C++11 and above
+
 __type If integral promotion can be applied to an rvalue of type `T`, then
 applies integral promotion to `T` and keeps cv-qualifiers of `T`,
 otherwise leaves `T` unchanged.

--- a/doc/make_signed.qbk
+++ b/doc/make_signed.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using make_signed_t = typename make_signed<T>::type; // C++11 and above
+
 __type If T is a signed integer type then the same type as T, if T is an 
 unsigned integer type then the corresponding signed type.  
 Otherwise if T is an enumerated or

--- a/doc/make_unsigned.qbk
+++ b/doc/make_unsigned.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using make_unsigned_t = typename make_unsigned<T>::type; // C++11 and above
+
 __type If T is a unsigned integer type then the same type as T, if T is an 
 signed integer type then the corresponding unsigned type.  
 Otherwise if T is an enumerated or

--- a/doc/promote.qbk
+++ b/doc/promote.qbk
@@ -13,6 +13,8 @@
       typedef __below type;
    };
   
+   template <class T> using promote_t = typename promote<T>::type; // C++11 and above
+
 __type If integral or floating point promotion can be applied to an rvalue
 of type `T`, then applies integral and floating point promotions to `T` and
 keeps cv-qualifiers of `T`, otherwise leaves `T` unchanged. See also

--- a/doc/remove_all_extents.qbk
+++ b/doc/remove_all_extents.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using remove_all_extents_t = typename remove_all_extents<T>::type; // C++11 and above
+
 __type If `T` is an array type, then removes all of the array bounds on `T`, otherwise
 leaves `T` unchanged.
 

--- a/doc/remove_const.qbk
+++ b/doc/remove_const.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using remove_const_t = typename remove_const<T>::type; // C++11 and above
+
 __type The same type as `T`, but with any /top level/ const-qualifier removed.
 
 __std_ref 3.9.3.

--- a/doc/remove_cv.qbk
+++ b/doc/remove_cv.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using remove_cv_t = typename remove_cv<T>::type; // C++11 and above
+
 __type The same type as `T`, but with any /top level/ cv-qualifiers removed.
 
 __std_ref 3.9.3.

--- a/doc/remove_extent.qbk
+++ b/doc/remove_extent.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using remove_extent_t = typename remove_extent<T>::type; // C++11 and above
+
 __type If `T` is an array type, then removes the topmost array bound, 
 otherwise leaves `T` unchanged.
 

--- a/doc/remove_pointer.qbk
+++ b/doc/remove_pointer.qbk
@@ -13,6 +13,8 @@
       typedef __below type;
    };
   
+   template <class T> using remove_pointer_t = typename remove_pointer<T>::type; // C++11 and above
+
 __type The same type as `T`, but with any pointer modifier removed.  Note that pointers to members are left unchanged: 
 removing the pointer decoration would result in an invalid type.
 

--- a/doc/remove_reference.qbk
+++ b/doc/remove_reference.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using remove_reference_t = typename remove_reference<T>::type; // C++11 and above
+
 __type The same type as `T`, but with any reference modifier removed.
 
 __std_ref 8.3.2.

--- a/doc/remove_volatile.qbk
+++ b/doc/remove_volatile.qbk
@@ -12,7 +12,9 @@
    {
       typedef __below type;
    };
-  
+   
+   template <class T> using remove_volatile_t = typename remove_volatile<T>::type; // C++11 and above
+
 __type The same type as `T`, but with any /top level/ volatile-qualifier removed.
 
 __std_ref 3.9.3.

--- a/include/boost/type_traits/add_const.hpp
+++ b/include/boost/type_traits/add_const.hpp
@@ -41,6 +41,12 @@ namespace boost {
       typedef T& type;
    };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using add_const_t = typename add_const<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_ADD_CONST_HPP_INCLUDED

--- a/include/boost/type_traits/add_cv.hpp
+++ b/include/boost/type_traits/add_cv.hpp
@@ -36,6 +36,12 @@ template <class T> struct add_cv{ typedef T const volatile type; };
 
 template <class T> struct add_cv<T&>{ typedef T& type; };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using add_cv_t = typename add_cv<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_ADD_CV_HPP_INCLUDED

--- a/include/boost/type_traits/add_lvalue_reference.hpp
+++ b/include/boost/type_traits/add_lvalue_reference.hpp
@@ -22,6 +22,12 @@ template <class T> struct add_lvalue_reference<T&&>
 };
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
+
+#endif
+
 }
 
 #endif  // BOOST_TYPE_TRAITS_EXT_ADD_LVALUE_REFERENCE__HPP

--- a/include/boost/type_traits/add_pointer.hpp
+++ b/include/boost/type_traits/add_pointer.hpp
@@ -56,6 +56,12 @@ struct add_pointer
 
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using add_pointer_t = typename add_pointer<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_ADD_POINTER_HPP_INCLUDED

--- a/include/boost/type_traits/add_rvalue_reference.hpp
+++ b/include/boost/type_traits/add_rvalue_reference.hpp
@@ -58,6 +58,12 @@ template <class T> struct add_rvalue_reference
    typedef typename boost::type_traits_detail::add_rvalue_reference_imp<T>::type type;
 };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
+
+#endif
+
 }  // namespace boost
 
 #endif  // BOOST_TYPE_TRAITS_EXT_ADD_RVALUE_REFERENCE__HPP

--- a/include/boost/type_traits/add_volatile.hpp
+++ b/include/boost/type_traits/add_volatile.hpp
@@ -35,6 +35,12 @@ template <class T> struct add_volatile{ typedef T volatile type; };
 
 template <class T> struct add_volatile<T&>{ typedef T& type; };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using add_volatile_t = typename add_volatile<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_ADD_VOLATILE_HPP_INCLUDED

--- a/include/boost/type_traits/conditional.hpp
+++ b/include/boost/type_traits/conditional.hpp
@@ -14,6 +14,12 @@ namespace boost {
 template <bool b, class T, class U> struct conditional { typedef T type; };
 template <class T, class U> struct conditional<false, T, U> { typedef U type; };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <bool b, class T, class U> using conditional_t = typename conditional<b, T, U>::type;
+
+#endif
+
 } // namespace boost
 
 

--- a/include/boost/type_traits/copy_cv.hpp
+++ b/include/boost/type_traits/copy_cv.hpp
@@ -29,6 +29,12 @@ public:
     typedef typename boost::conditional<boost::is_volatile<U>::value, typename boost::add_volatile<CT>::type, CT>::type type;
 };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T, class U> using copy_cv_t = typename copy_cv<T, U>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // #ifndef BOOST_TYPE_TRAITS_COPY_CV_HPP_INCLUDED

--- a/include/boost/type_traits/decay.hpp
+++ b/include/boost/type_traits/decay.hpp
@@ -37,6 +37,12 @@ namespace boost
        typedef typename boost::detail::decay_imp<Ty, boost::is_array<Ty>::value, boost::is_function<Ty>::value>::type type;
     };
     
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using decay_t = typename decay<T>::type;
+
+#endif
+
 } // namespace boost
 
 

--- a/include/boost/type_traits/floating_point_promotion.hpp
+++ b/include/boost/type_traits/floating_point_promotion.hpp
@@ -14,6 +14,12 @@ namespace boost {
    template<> struct floating_point_promotion<float volatile>{ typedef double volatile type; };
    template<> struct floating_point_promotion<float const volatile> { typedef double const volatile type; };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using floating_point_promotion_t = typename floating_point_promotion<T>::type;
+
+#endif
+
 }
 
 #endif // #ifndef FILE_boost_type_traits_floating_point_promotion_hpp_INCLUDED

--- a/include/boost/type_traits/integral_promotion.hpp
+++ b/include/boost/type_traits/integral_promotion.hpp
@@ -175,6 +175,12 @@ public:
    typedef typename boost::type_traits::detail::integral_promotion<T, tag_type::value>::type type;
 };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using integral_promotion_t = typename integral_promotion<T>::type;
+
+#endif
+
 }
 
 #endif // #ifndef FILE_boost_type_traits_integral_promotion_hpp_INCLUDED

--- a/include/boost/type_traits/make_signed.hpp
+++ b/include/boost/type_traits/make_signed.hpp
@@ -125,6 +125,12 @@ public:
    >::type type;
 };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using make_signed_t = typename make_signed<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_ADD_REFERENCE_HPP_INCLUDED

--- a/include/boost/type_traits/make_unsigned.hpp
+++ b/include/boost/type_traits/make_unsigned.hpp
@@ -124,6 +124,12 @@ public:
    >::type type;
 };
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using make_unsigned_t = typename make_unsigned<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_ADD_REFERENCE_HPP_INCLUDED

--- a/include/boost/type_traits/promote.hpp
+++ b/include/boost/type_traits/promote.hpp
@@ -14,6 +14,12 @@ namespace boost {
 
 template<class T> struct promote : public integral_promotion<typename floating_point_promotion<T>::type>{};
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using promote_t = typename promote<T>::type;
+
+#endif
+
 }
 
 #endif // #ifndef FILE_boost_type_traits_promote_hpp_INCLUDED

--- a/include/boost/type_traits/remove_all_extents.hpp
+++ b/include/boost/type_traits/remove_all_extents.hpp
@@ -30,6 +30,12 @@ template <class T> struct remove_all_extents<T const volatile[]> : public remove
 #endif
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using remove_all_extents_t = typename remove_all_extents<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_REMOVE_BOUNDS_HPP_INCLUDED

--- a/include/boost/type_traits/remove_const.hpp
+++ b/include/boost/type_traits/remove_const.hpp
@@ -28,6 +28,12 @@ namespace boost {
 #endif
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using remove_const_t = typename remove_const<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_REMOVE_CONST_HPP_INCLUDED

--- a/include/boost/type_traits/remove_cv.hpp
+++ b/include/boost/type_traits/remove_cv.hpp
@@ -34,6 +34,11 @@ template <class T> struct remove_cv<T volatile[]>{ typedef T type[]; };
 #endif
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using remove_cv_t = typename remove_cv<T>::type;
+
+#endif
 
 } // namespace boost
 

--- a/include/boost/type_traits/remove_extent.hpp
+++ b/include/boost/type_traits/remove_extent.hpp
@@ -30,6 +30,12 @@ template <typename T> struct remove_extent<T const volatile[]> { typedef T const
 #endif
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using remove_extent_t = typename remove_extent<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_REMOVE_BOUNDS_HPP_INCLUDED

--- a/include/boost/type_traits/remove_pointer.hpp
+++ b/include/boost/type_traits/remove_pointer.hpp
@@ -72,6 +72,12 @@ template <class T> struct remove_pointer<T*const volatile>{ typedef T type; };
 
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using remove_pointer_t = typename remove_pointer<T>::type;
+
+#endif
+
 } // namespace boost
 
 #endif // BOOST_TT_REMOVE_POINTER_HPP_INCLUDED

--- a/include/boost/type_traits/remove_reference.hpp
+++ b/include/boost/type_traits/remove_reference.hpp
@@ -48,6 +48,11 @@ template <class T> struct remove_reference<T&volatile>{ typedef T type; };
 template <class T> struct remove_reference<T&const volatile>{ typedef T type; };
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using remove_reference_t = typename remove_reference<T>::type;
+
+#endif
 
 } // namespace boost
 

--- a/include/boost/type_traits/remove_volatile.hpp
+++ b/include/boost/type_traits/remove_volatile.hpp
@@ -28,6 +28,11 @@ namespace boost {
 #endif
 #endif
 
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+   template <class T> using remove_volatile_t = typename remove_volatile<T>::type;
+
+#endif
 
 } // namespace boost
 

--- a/test/cxx14_aliases_test.cpp
+++ b/test/cxx14_aliases_test.cpp
@@ -1,0 +1,46 @@
+
+//  Copyright Peter Dimov 2017
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
+
+#include "test.hpp"
+#include "check_type.hpp"
+#ifdef TEST_STD
+#  include <type_traits>
+#else
+#  include <boost/type_traits.hpp>
+#endif
+#include <iostream>
+
+TT_TEST_BEGIN(cxx14_aliases_test)
+{
+#if !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
+
+    BOOST_CHECK_TYPE(tt::add_const_t<int>, int const);
+    BOOST_CHECK_TYPE(tt::add_cv_t<int>, int const volatile);
+    BOOST_CHECK_TYPE(tt::add_lvalue_reference_t<int>, int&);
+    BOOST_CHECK_TYPE(tt::add_pointer_t<int>, int*);
+    BOOST_CHECK_TYPE(tt::add_rvalue_reference_t<int>, int&&);
+    BOOST_CHECK_TYPE(tt::add_volatile_t<int>, int volatile);
+    BOOST_CHECK_TYPE3(tt::common_type_t<char, short>, int);
+    BOOST_CHECK_TYPE4(tt::conditional_t<true, char, short>, char);
+    BOOST_CHECK_TYPE4(tt::conditional_t<false, char, short>, short);
+    BOOST_CHECK_TYPE3(tt::copy_cv_t<char, short const volatile>, char const volatile);
+    BOOST_CHECK_TYPE(tt::decay_t<char const(&)[7]>, char const*);
+    BOOST_CHECK_TYPE(tt::make_signed_t<unsigned char>, signed char);
+    BOOST_CHECK_TYPE(tt::make_unsigned_t<signed char>, unsigned char);
+    BOOST_CHECK_TYPE(tt::remove_all_extents_t<int[][10][20]>, int);
+    BOOST_CHECK_TYPE(tt::remove_const_t<int const>, int);
+    BOOST_CHECK_TYPE(tt::remove_cv_t<int const volatile>, int);
+    BOOST_CHECK_TYPE(tt::remove_extent_t<int[]>, int);
+    BOOST_CHECK_TYPE(tt::remove_pointer_t<int*>, int);
+    BOOST_CHECK_TYPE(tt::remove_reference_t<int&>, int);
+    BOOST_CHECK_TYPE(tt::remove_volatile_t<int volatile>, int);
+    BOOST_CHECK_TYPE(tt::floating_point_promotion_t<float>, double);
+    BOOST_CHECK_TYPE(tt::integral_promotion_t<char>, int);
+    BOOST_CHECK_TYPE(tt::promote_t<char>, int);
+
+#endif
+}
+TT_TEST_END


### PR DESCRIPTION
This adds C++14-style _t aliases to the transformation traits. The best way to test these additions would probably be to change the transformation testing macros to automatically add the additional test for X##_t, but I'm not familiar enough with the type_traits testing infrastructure so I haven't done it.