### PR TITLE
Add missing includes

### DIFF
--- a/include/boost/type_traits/conditional.hpp
+++ b/include/boost/type_traits/conditional.hpp
@@ -9,6 +9,8 @@
 #ifndef BOOST_TT_CONDITIONAL_HPP_INCLUDED
 #define BOOST_TT_CONDITIONAL_HPP_INCLUDED
 
+#include <boost/config.hpp>
+
 namespace boost {
 
 template <bool b, class T, class U> struct conditional { typedef T type; };

--- a/include/boost/type_traits/detail/has_postfix_operator.hpp
+++ b/include/boost/type_traits/detail/has_postfix_operator.hpp
@@ -23,7 +23,7 @@
 #   pragma GCC system_header
 #elif defined(BOOST_MSVC)
 #   pragma warning ( push )
-#   pragma warning ( disable : 4244 4913)
+#   pragma warning ( disable : 4244 4913 4800)
 #   if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
 #       pragma warning ( disable : 6334)
 #   endif

--- a/include/boost/type_traits/detail/has_prefix_operator.hpp
+++ b/include/boost/type_traits/detail/has_prefix_operator.hpp
@@ -31,7 +31,7 @@
 #   pragma GCC system_header
 #elif defined(BOOST_MSVC)
 #   pragma warning ( push )
-#   pragma warning ( disable : 4146 4804 4913 4244)
+#   pragma warning ( disable : 4146 4804 4913 4244 4800)
 #   if BOOST_WORKAROUND(BOOST_MSVC_FULL_VER, >= 140050000)
 #       pragma warning ( disable : 6334)
 #   endif

--- a/include/boost/type_traits/floating_point_promotion.hpp
+++ b/include/boost/type_traits/floating_point_promotion.hpp
@@ -6,6 +6,8 @@
 #ifndef FILE_boost_type_traits_floating_point_promotion_hpp_INCLUDED
 #define FILE_boost_type_traits_floating_point_promotion_hpp_INCLUDED
 
+#include <boost/config.hpp>
+
 namespace boost {
 
    template<class T> struct floating_point_promotion { typedef T type; };

--- a/include/boost/type_traits/remove_pointer.hpp
+++ b/include/boost/type_traits/remove_pointer.hpp
@@ -10,6 +10,7 @@
 #define BOOST_TT_REMOVE_POINTER_HPP_INCLUDED
 
 #include <boost/config.hpp>
+#include <boost/config/workaround.hpp>
 
 #if defined(BOOST_MSVC)
 #include <boost/type_traits/remove_cv.hpp>

--- a/include/boost/type_traits/type_identity.hpp
+++ b/include/boost/type_traits/type_identity.hpp
@@ -9,6 +9,8 @@
 //  http://www.boost.org/LICENSE_1_0.txt
 //
 
+#include <boost/config.hpp>
+
 namespace boost
 {
 

--- a/test/add_const_test.cpp
+++ b/test/add_const_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/add_const.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(add_const_test_1, ::tt::add_const, const, const)
 BOOST_DECL_TRANSFORM_TEST(add_const_test_2, ::tt::add_const, volatile, volatile const)

--- a/test/add_cv_test.cpp
+++ b/test/add_cv_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/add_cv.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(add_cv_test_1, ::tt::add_cv, const, const volatile)
 BOOST_DECL_TRANSFORM_TEST(add_cv_test_2, ::tt::add_cv, volatile, volatile const)

--- a/test/add_lvalue_reference_test.cpp
+++ b/test/add_lvalue_reference_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/add_lvalue_reference.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(add_lvalue_reference_test_1, ::tt::add_lvalue_reference, const, const&)
 BOOST_DECL_TRANSFORM_TEST(add_lvalue_reference_test_2, ::tt::add_lvalue_reference, volatile, volatile&)

--- a/test/add_pointer_test.cpp
+++ b/test/add_pointer_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/add_pointer.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(add_pointer_test_1, ::tt::add_pointer, const, const*)
 BOOST_DECL_TRANSFORM_TEST(add_pointer_test_2, ::tt::add_pointer, volatile, volatile*)

--- a/test/add_reference_test.cpp
+++ b/test/add_reference_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/add_reference.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(add_reference_test_1, ::tt::add_reference, const, const&)
 BOOST_DECL_TRANSFORM_TEST(add_reference_test_2, ::tt::add_reference, volatile, volatile&)

--- a/test/add_rvalue_reference_test.cpp
+++ b/test/add_rvalue_reference_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "../../type_traits/test/test.hpp"
-#include "../../type_traits/test/check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/add_rvalue_reference.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 #ifdef BOOST_NO_CXX11_RVALUE_REFERENCES
 

--- a/test/add_volatile_test.cpp
+++ b/test/add_volatile_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/add_volatile.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(add_volatile_test_1, ::tt::add_volatile, const, const volatile)
 BOOST_DECL_TRANSFORM_TEST(add_volatile_test_2, ::tt::add_volatile, volatile, volatile)

--- a/test/aligned_storage_a2_test.cpp
+++ b/test/aligned_storage_a2_test.cpp
@@ -8,8 +8,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #  include <boost/type_traits/type_with_alignment.hpp> // max_align and long_long_type
@@ -18,6 +16,8 @@
 #  include <boost/type_traits/aligned_storage.hpp>
 #  include <boost/type_traits/is_pod.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 template <class T>
 union must_be_pod

--- a/test/aligned_storage_empy_test.cpp
+++ b/test/aligned_storage_empy_test.cpp
@@ -4,8 +4,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #  include <boost/type_traits/type_with_alignment.hpp> // max_align and long_long_type
@@ -14,6 +12,8 @@
 #  include <boost/type_traits/aligned_storage.hpp>
 #  include <boost/type_traits/is_pod.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 
 namespace

--- a/test/aligned_storage_test.cpp
+++ b/test/aligned_storage_test.cpp
@@ -4,8 +4,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #  include <boost/type_traits/type_with_alignment.hpp> // max_align and long_long_type
@@ -14,6 +12,8 @@
 #  include <boost/type_traits/aligned_storage.hpp>
 #  include <boost/type_traits/is_pod.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 template <class T>
 union must_be_pod

--- a/test/alignment_of_a2_test.cpp
+++ b/test/alignment_of_a2_test.cpp
@@ -8,13 +8,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/alignment_of.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 //
 // Need to defined some member functions for empty_UDT,

--- a/test/alignment_of_test.cpp
+++ b/test/alignment_of_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/alignment_of.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 //
 // Need to defined some member function for empty_UDT,

--- a/test/common_type_2_test.cpp
+++ b/test/common_type_2_test.cpp
@@ -7,13 +7,13 @@
 
 #define BOOST_COMMON_TYPE_DONT_USE_TYPEOF 1
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/common_type.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 #ifdef BOOST_INTEL

--- a/test/common_type_3_test.cpp
+++ b/test/common_type_3_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/common_type.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 TT_TEST_BEGIN(common_type_3)

--- a/test/common_type_4_test.cpp
+++ b/test/common_type_4_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/common_type.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 TT_TEST_BEGIN(common_type_4)

--- a/test/common_type_5_test.cpp
+++ b/test/common_type_5_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/common_type.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 template<class T> struct X

--- a/test/common_type_6_test.cpp
+++ b/test/common_type_6_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/common_type.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 struct X {};

--- a/test/common_type_sfinae2_test.cpp
+++ b/test/common_type_sfinae2_test.cpp
@@ -4,14 +4,14 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/common_type.hpp>
 #  include <boost/type_traits/integral_constant.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 #include <iostream>
 
 typedef char(&s1)[1];

--- a/test/common_type_sfinae_test.cpp
+++ b/test/common_type_sfinae_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/common_type.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 struct X {};

--- a/test/common_type_test.cpp
+++ b/test/common_type_test.cpp
@@ -5,13 +5,13 @@
 //  Distributed under the Boost Software License, Version 1.0.
 //  See http://www.boost.org/LICENSE_1_0.txt
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/common_type.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 #ifdef BOOST_INTEL

--- a/test/conditional_test.cpp
+++ b/test/conditional_test.cpp
@@ -4,14 +4,14 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/conditional.hpp>
 #endif
 #include <boost/type_traits/is_same.hpp>
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(conditional)
 

--- a/test/copy_cv_test.cpp
+++ b/test/copy_cv_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/copy_cv.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 TT_TEST_BEGIN(copy_cv)

--- a/test/cxx14_aliases_test.cpp
+++ b/test/cxx14_aliases_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 #include <iostream>
 
 TT_TEST_BEGIN(cxx14_aliases_test)

--- a/test/decay_test.cpp
+++ b/test/decay_test.cpp
@@ -4,15 +4,15 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/decay.hpp>
 #  include <boost/type_traits/is_same.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
+#include "check_integral_constant.hpp"
 #include <iostream>
 #include <string>
 #include <utility>

--- a/test/extent_test.cpp
+++ b/test/extent_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/extent.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(extent)
 

--- a/test/floating_point_promotion_test.cpp
+++ b/test/floating_point_promotion_test.cpp
@@ -1,0 +1,38 @@
+
+//  (C) Copyright John Maddock 2010. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifdef TEST_STD
+#  include <type_traits>
+#else
+#  include <boost/type_traits/floating_point_promotion.hpp>
+#endif
+#include <boost/type_traits/is_same.hpp>
+#include "test.hpp"
+#include "check_integral_constant.hpp"
+
+TT_TEST_BEGIN(floating_point_promotion)
+
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<void>::type, void>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<void const>::type, void const>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<void volatile>::type, void volatile>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<void const volatile>::type, void const volatile>::value), true);
+
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<float>::type, double>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<float const>::type, double const>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<float volatile>::type, double volatile>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<float const volatile>::type, double const volatile>::value), true);
+
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<double>::type, double>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<double const>::type, double const>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<double volatile>::type, double volatile>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<double const volatile>::type, double const volatile>::value), true);
+
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<float&>::type, float&>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<float const&>::type, float const&>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<float volatile&>::type, float volatile&>::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_same< ::tt::floating_point_promotion<float const volatile&>::type, float const volatile&>::value), true);
+
+TT_TEST_END

--- a/test/function_traits_test.cpp
+++ b/test/function_traits_test.cpp
@@ -4,14 +4,14 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/function_traits.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
+#include "check_integral_constant.hpp"
 
 typedef void(pf_zero1)();
 typedef int(pf_zero2)();

--- a/test/has_binary_classes0_test.cpp
+++ b/test/has_binary_classes0_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes1_test.cpp
+++ b/test/has_binary_classes1_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes2_test.cpp
+++ b/test/has_binary_classes2_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes3_test.cpp
+++ b/test/has_binary_classes3_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes4_test.cpp
+++ b/test/has_binary_classes4_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes5_test.cpp
+++ b/test/has_binary_classes5_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes6_test.cpp
+++ b/test/has_binary_classes6_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes7_test.cpp
+++ b/test/has_binary_classes7_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes8_test.cpp
+++ b/test/has_binary_classes8_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_binary_classes9_test.cpp
+++ b/test/has_binary_classes9_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_binary_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_bit_and_assign_test.cpp
+++ b/test/has_bit_and_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_bit_and_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_bit_and_assign
 #define BOOST_TT_TRAIT_OP &=

--- a/test/has_bit_and_test.cpp
+++ b/test/has_bit_and_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_bit_and.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_bit_and
 #define BOOST_TT_TRAIT_OP &

--- a/test/has_bit_or_assign_test.cpp
+++ b/test/has_bit_or_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_bit_or_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_bit_or_assign
 #define BOOST_TT_TRAIT_OP |=

--- a/test/has_bit_or_test.cpp
+++ b/test/has_bit_or_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_bit_or.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_bit_or
 #define BOOST_TT_TRAIT_OP |

--- a/test/has_bit_xor_assign_test.cpp
+++ b/test/has_bit_xor_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_bit_xor_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_bit_xor_assign
 #define BOOST_TT_TRAIT_OP ^=

--- a/test/has_bit_xor_test.cpp
+++ b/test/has_bit_xor_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_bit_xor.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_bit_xor
 #define BOOST_TT_TRAIT_OP ^

--- a/test/has_complement_test.cpp
+++ b/test/has_complement_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_complement.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_complement
 #define BOOST_TT_TRAIT_OP ~

--- a/test/has_dereference_test.cpp
+++ b/test/has_dereference_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_dereference.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_dereference
 #define BOOST_TT_TRAIT_OP *

--- a/test/has_divides_assign_test.cpp
+++ b/test/has_divides_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_divides_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_divides_assign
 #define BOOST_TT_TRAIT_OP /=

--- a/test/has_divides_test.cpp
+++ b/test/has_divides_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_divides.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_divides
 #define BOOST_TT_TRAIT_OP /

--- a/test/has_equal_to_test.cpp
+++ b/test/has_equal_to_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_equal_to.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_equal_to
 #define BOOST_TT_TRAIT_OP ==

--- a/test/has_greater_equal_test.cpp
+++ b/test/has_greater_equal_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_greater_equal.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_greater_equal
 #define BOOST_TT_TRAIT_OP >=

--- a/test/has_greater_test.cpp
+++ b/test/has_greater_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_greater.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_greater
 #define BOOST_TT_TRAIT_OP >

--- a/test/has_left_shift_assign_test.cpp
+++ b/test/has_left_shift_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_left_shift_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_left_shift_assign
 #define BOOST_TT_TRAIT_OP <<=

--- a/test/has_left_shift_test.cpp
+++ b/test/has_left_shift_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_left_shift.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_left_shift
 #define BOOST_TT_TRAIT_OP <<

--- a/test/has_less_equal_test.cpp
+++ b/test/has_less_equal_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_less_equal.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_less_equal
 #define BOOST_TT_TRAIT_OP <=

--- a/test/has_less_test.cpp
+++ b/test/has_less_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_less.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_less
 #define BOOST_TT_TRAIT_OP <

--- a/test/has_logical_and_test.cpp
+++ b/test/has_logical_and_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_logical_and.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_logical_and
 #define BOOST_TT_TRAIT_OP &&

--- a/test/has_logical_not_test.cpp
+++ b/test/has_logical_not_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_logical_not.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_logical_not
 #define BOOST_TT_TRAIT_OP !

--- a/test/has_logical_or_test.cpp
+++ b/test/has_logical_or_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_logical_or.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_logical_or
 #define BOOST_TT_TRAIT_OP ||

--- a/test/has_minus_assign_test.cpp
+++ b/test/has_minus_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_minus_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_minus_assign
 #define BOOST_TT_TRAIT_OP -=

--- a/test/has_minus_test.cpp
+++ b/test/has_minus_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_minus.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_minus
 #define BOOST_TT_TRAIT_OP -

--- a/test/has_modulus_assign_test.cpp
+++ b/test/has_modulus_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_modulus_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_modulus_assign
 #define BOOST_TT_TRAIT_OP %=

--- a/test/has_modulus_test.cpp
+++ b/test/has_modulus_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_modulus.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_modulus
 #define BOOST_TT_TRAIT_OP %

--- a/test/has_multiplies_assign_test.cpp
+++ b/test/has_multiplies_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_multiplies_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_multiplies_assign
 #define BOOST_TT_TRAIT_OP *=

--- a/test/has_multiplies_test.cpp
+++ b/test/has_multiplies_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_multiplies.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_multiplies
 #define BOOST_TT_TRAIT_OP *

--- a/test/has_negate_test.cpp
+++ b/test/has_negate_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_negate.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_negate
 #define BOOST_TT_TRAIT_OP -

--- a/test/has_not_equal_to_test.cpp
+++ b/test/has_not_equal_to_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_not_equal_to.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_not_equal_to
 #define BOOST_TT_TRAIT_OP !=

--- a/test/has_nothrow_assign_test.cpp
+++ b/test/has_nothrow_assign_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_nothrow_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 

--- a/test/has_nothrow_constr_test.cpp
+++ b/test/has_nothrow_constr_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_nothrow_constructor.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 class bug11324_base
 {

--- a/test/has_nothrow_copy_test.cpp
+++ b/test/has_nothrow_copy_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_nothrow_copy.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 struct non_copy
 {

--- a/test/has_nothrow_destructor_test.cpp
+++ b/test/has_nothrow_destructor_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_nothrow_destructor.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifdef BOOST_MSVC
 #pragma warning(disable:4290) // exception spec ignored

--- a/test/has_operator_new_test.cpp
+++ b/test/has_operator_new_test.cpp
@@ -3,9 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_new_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-#include <boost/type_traits/has_new_operator.hpp>
 
 #ifdef BOOST_INTEL
 //  remark #1720: function "class_with_new_op::operator new" has no corresponding member operator delete (to be called if an exception is thrown during initialization of an allocated object)

--- a/test/has_plus_assign_test.cpp
+++ b/test/has_plus_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_plus_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_plus_assign
 #define BOOST_TT_TRAIT_OP +=

--- a/test/has_plus_test.cpp
+++ b/test/has_plus_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_plus.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_plus
 #define BOOST_TT_TRAIT_OP +

--- a/test/has_post_decrement_test.cpp
+++ b/test/has_post_decrement_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_post_decrement.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_post_decrement
 #define BOOST_TT_TRAIT_OP --

--- a/test/has_post_increment_test.cpp
+++ b/test/has_post_increment_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_post_increment.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_post_increment
 #define BOOST_TT_TRAIT_OP ++

--- a/test/has_postfix_classes0_test.cpp
+++ b/test/has_postfix_classes0_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_postfix_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_postfix_classes1_test.cpp
+++ b/test/has_postfix_classes1_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_postfix_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_postfix_classes2_test.cpp
+++ b/test/has_postfix_classes2_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_postfix_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_postfix_classes3_test.cpp
+++ b/test/has_postfix_classes3_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_postfix_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_pre_decrement_test.cpp
+++ b/test/has_pre_decrement_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_pre_decrement.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_pre_decrement
 #define BOOST_TT_TRAIT_OP --

--- a/test/has_pre_increment_test.cpp
+++ b/test/has_pre_increment_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_pre_increment.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_pre_increment
 #define BOOST_TT_TRAIT_OP ++

--- a/test/has_prefix_classes0_test.cpp
+++ b/test/has_prefix_classes0_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_prefix_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_prefix_classes1_test.cpp
+++ b/test/has_prefix_classes1_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_prefix_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_prefix_classes2_test.cpp
+++ b/test/has_prefix_classes2_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_prefix_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_prefix_classes3_test.cpp
+++ b/test/has_prefix_classes3_test.cpp
@@ -3,10 +3,9 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/type_traits/has_operator.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-
-#include <boost/type_traits/has_operator.hpp>
 #include "has_prefix_classes.hpp"
 
 TT_TEST_BEGIN(BOOST_TT_TRAIT_NAME)

--- a/test/has_right_shift_assign_test.cpp
+++ b/test/has_right_shift_assign_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_right_shift_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_right_shift_assign
 #define BOOST_TT_TRAIT_OP >>=

--- a/test/has_right_shift_test.cpp
+++ b/test/has_right_shift_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_right_shift.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_right_shift
 #define BOOST_TT_TRAIT_OP >>

--- a/test/has_trivial_assign_test.cpp
+++ b/test/has_trivial_assign_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_trivial_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 struct non_assignable
 {

--- a/test/has_trivial_constr_test.cpp
+++ b/test/has_trivial_constr_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_trivial_constructor.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 
 class bug11324_base

--- a/test/has_trivial_copy_test.cpp
+++ b/test/has_trivial_copy_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_trivial_copy.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 

--- a/test/has_trivial_destructor_test.cpp
+++ b/test/has_trivial_destructor_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_trivial_destructor.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 

--- a/test/has_trivial_move_assign_test.cpp
+++ b/test/has_trivial_move_assign_test.cpp
@@ -5,13 +5,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_trivial_move_assign.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 

--- a/test/has_trivial_move_constructor_test.cpp
+++ b/test/has_trivial_move_constructor_test.cpp
@@ -5,13 +5,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_trivial_move_constructor.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 

--- a/test/has_unary_minus_test.cpp
+++ b/test/has_unary_minus_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_unary_minus.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_unary_minus
 #define BOOST_TT_TRAIT_OP -

--- a/test/has_unary_plus_test.cpp
+++ b/test/has_unary_plus_test.cpp
@@ -3,14 +3,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_unary_plus.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #define BOOST_TT_TRAIT_NAME has_unary_plus
 #define BOOST_TT_TRAIT_OP +

--- a/test/has_virtual_destructor_test.cpp
+++ b/test/has_virtual_destructor_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/has_virtual_destructor.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #include <iostream>
 #include <stdexcept>

--- a/test/is_abstract_test.cpp
+++ b/test/is_abstract_test.cpp
@@ -5,13 +5,13 @@
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_abstract.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifdef BOOST_MSVC
 #pragma warning(disable: 4505)

--- a/test/is_arithmetic_test.cpp
+++ b/test/is_arithmetic_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_arithmetic.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_arithmetic)
 

--- a/test/is_array_test.cpp
+++ b/test/is_array_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_array.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 struct convertible_to_pointer
 {

--- a/test/is_assignable_test.cpp
+++ b/test/is_assignable_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_assignable.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 

--- a/test/is_base_and_derived_test.cpp
+++ b/test/is_base_and_derived_test.cpp
@@ -5,13 +5,13 @@
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_base_and_derived.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 //
 // Additional tests added for VC7.1 bug, 2005/04/21

--- a/test/is_base_of_test.cpp
+++ b/test/is_base_of_test.cpp
@@ -5,13 +5,13 @@
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_base_of.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 
 

--- a/test/is_class_test.cpp
+++ b/test/is_class_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_class.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 #include <iostream>
 
 TT_TEST_BEGIN(is_class)

--- a/test/is_complex_test.cpp
+++ b/test/is_complex_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_complex.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 #include <iostream>
 
 struct bad_struct

--- a/test/is_compound_test.cpp
+++ b/test/is_compound_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_compound.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_compound)
 

--- a/test/is_const_test.cpp
+++ b/test/is_const_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_const.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_const)
 

--- a/test/is_constructible_test.cpp
+++ b/test/is_constructible_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_constructible.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 
 struct non_copy_constructible

--- a/test/is_convertible_test.cpp
+++ b/test/is_convertible_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_convertible.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 #include <boost/utility/enable_if.hpp>
 
 

--- a/test/is_copy_assignable_test.cpp
+++ b/test/is_copy_assignable_test.cpp
@@ -4,15 +4,14 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //#define TEST_STD
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_copy_assignable.hpp>
 #endif
-
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #include <boost/move/core.hpp>
 

--- a/test/is_copy_constructible_test.cpp
+++ b/test/is_copy_constructible_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_copy_constructible.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #include <boost/move/core.hpp>
 

--- a/test/is_default_constr_test.cpp
+++ b/test/is_default_constr_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_default_constructible.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 class bug11324_base
 {

--- a/test/is_destructible_test.cpp
+++ b/test/is_destructible_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_destructible.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #if !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
 

--- a/test/is_empty_test.cpp
+++ b/test/is_empty_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_empty.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 struct non_default_constructable_UDT
 {

--- a/test/is_enum_test.cpp
+++ b/test/is_enum_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_enum.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #ifndef BOOST_NO_CXX11_SCOPED_ENUMS
 

--- a/test/is_final_test.cpp
+++ b/test/is_final_test.cpp
@@ -5,13 +5,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_final.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 #include <iostream>
 
 TT_TEST_BEGIN(is_final)

--- a/test/is_float_test.cpp
+++ b/test/is_float_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_float.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_float)
 

--- a/test/is_floating_point_test.cpp
+++ b/test/is_floating_point_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_floating_point.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_floating_point)
 

--- a/test/is_function_test.cpp
+++ b/test/is_function_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_function.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_function)
 

--- a/test/is_fundamental_test.cpp
+++ b/test/is_fundamental_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_fundamental.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_fundamental)
 

--- a/test/is_integral_test.cpp
+++ b/test/is_integral_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_integral.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_integral)
 

--- a/test/is_lvalue_reference_test.cpp
+++ b/test/is_lvalue_reference_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_lvalue_reference.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_lvalue_reference)
 

--- a/test/is_member_func_test.cpp
+++ b/test/is_member_func_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_member_function_pointer.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_member_function_pointer)
 

--- a/test/is_member_obj_test.cpp
+++ b/test/is_member_obj_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_member_object_pointer.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 typedef const double (UDT::*mp2) ;
 

--- a/test/is_member_pointer_test.cpp
+++ b/test/is_member_pointer_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_member_pointer.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_member_pointer)
 

--- a/test/is_object_test.cpp
+++ b/test/is_object_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_object.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_object)
 

--- a/test/is_pod_test.cpp
+++ b/test/is_pod_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_pod.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_pod)
 

--- a/test/is_pointer_test.cpp
+++ b/test/is_pointer_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_pointer.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_pointer)
 

--- a/test/is_polymorphic_test.cpp
+++ b/test/is_polymorphic_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_polymorphic.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #include <exception>
 #include <new>

--- a/test/is_reference_test.cpp
+++ b/test/is_reference_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_reference.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_reference)
 

--- a/test/is_rvalue_reference_test.cpp
+++ b/test/is_rvalue_reference_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_rvalue_reference.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_rvalue_reference)
 

--- a/test/is_same_test.cpp
+++ b/test/is_same_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_same.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_same)
 

--- a/test/is_scalar_test.cpp
+++ b/test/is_scalar_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_scalar.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_scalar)
 

--- a/test/is_signed_test.cpp
+++ b/test/is_signed_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_signed.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #include <climits>
 

--- a/test/is_stateless_test.cpp
+++ b/test/is_stateless_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_stateless.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_stateless)
 

--- a/test/is_union_test.cpp
+++ b/test/is_union_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_union.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 #include <iostream>
 
 TT_TEST_BEGIN(is_union)

--- a/test/is_unsigned_test.cpp
+++ b/test/is_unsigned_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_unsigned.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #include <climits>
 

--- a/test/is_virtual_base_of_test.cpp
+++ b/test/is_virtual_base_of_test.cpp
@@ -5,9 +5,9 @@
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 
+#include <boost/type_traits/is_virtual_base_of.hpp>
 #include "test.hpp"
 #include "check_integral_constant.hpp"
-#include <boost/type_traits/is_virtual_base_of.hpp>
 
 // for bug report 3317: https://svn.boost.org/trac/boost/ticket/3317
 class B

--- a/test/is_void_test.cpp
+++ b/test/is_void_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_void.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_void)
 

--- a/test/is_volatile_test.cpp
+++ b/test/is_volatile_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_volatile.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(is_volatile)
 

--- a/test/make_signed_test.cpp
+++ b/test/make_signed_test.cpp
@@ -4,14 +4,14 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/make_signed.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(make_signed)
 // signed types:

--- a/test/make_unsigned_test.cpp
+++ b/test/make_unsigned_test.cpp
@@ -4,14 +4,14 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/make_unsigned.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(make_unsigned)
 // signed types:

--- a/test/make_void_test.cpp
+++ b/test/make_void_test.cpp
@@ -7,14 +7,13 @@ Version 1.0. (See accompanying file LICENSE_1_0.txt
 or copy at http://www.boost.org/LICENSE_1_0.txt)
 */
 
-#include "test.hpp"
-#include "check_type.hpp"
-
 #ifdef TEST_STD
 #include <type_traits>
 #else
 #include <boost/type_traits/make_void.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 TT_TEST_BEGIN(make_void)
 

--- a/test/rank_test.cpp
+++ b/test/rank_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/rank.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(rank)
 

--- a/test/remove_all_extents_test.cpp
+++ b/test/remove_all_extents_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_all_extents.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(remove_all_extents_test_1, ::tt::remove_all_extents, const, const)
 BOOST_DECL_TRANSFORM_TEST(remove_all_extents_test_2, ::tt::remove_all_extents, volatile, volatile)

--- a/test/remove_bounds_test.cpp
+++ b/test/remove_bounds_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_bounds.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(remove_bounds_test_1, ::tt::remove_bounds, const, const)
 BOOST_DECL_TRANSFORM_TEST(remove_bounds_test_2, ::tt::remove_bounds, volatile, volatile)

--- a/test/remove_const_test.cpp
+++ b/test/remove_const_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_const.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST3(remove_const_test_1, ::tt::remove_const, const)
 BOOST_DECL_TRANSFORM_TEST(remove_const_test_2, ::tt::remove_const, volatile, volatile)

--- a/test/remove_cv_ref_test.cpp
+++ b/test/remove_cv_ref_test.cpp
@@ -5,13 +5,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_cv_ref.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST3(remove_cv_ref_test_1, ::tt::remove_cv_ref, const)
 BOOST_DECL_TRANSFORM_TEST3(remove_cv_ref_test_2, ::tt::remove_cv_ref, volatile)

--- a/test/remove_cv_test.cpp
+++ b/test/remove_cv_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_cv.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST3(remove_cv_test_1, ::tt::remove_cv, const)
 BOOST_DECL_TRANSFORM_TEST3(remove_cv_test_2, ::tt::remove_cv, volatile)

--- a/test/remove_extent_test.cpp
+++ b/test/remove_extent_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_extent.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(remove_extent_test_1, ::tt::remove_extent, const, const)
 BOOST_DECL_TRANSFORM_TEST(remove_extent_test_2, ::tt::remove_extent, volatile, volatile)

--- a/test/remove_pointer_test.cpp
+++ b/test/remove_pointer_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_pointer.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(remove_pointer_test_1, ::tt::remove_pointer, const, const)
 BOOST_DECL_TRANSFORM_TEST(remove_pointer_test_2, ::tt::remove_pointer, volatile, volatile)

--- a/test/remove_reference_test.cpp
+++ b/test/remove_reference_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_reference.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(remove_reference_test_1, ::tt::remove_reference, const, const)
 BOOST_DECL_TRANSFORM_TEST(remove_reference_test_2, ::tt::remove_reference, volatile, volatile)

--- a/test/remove_volatile_test.cpp
+++ b/test/remove_volatile_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/remove_volatile.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(remove_volatile_test_1, ::tt::remove_volatile, const, const)
 BOOST_DECL_TRANSFORM_TEST3(remove_volatile_test_2, ::tt::remove_volatile, volatile)

--- a/test/tricky_abstract_type_test.cpp
+++ b/test/tricky_abstract_type_test.cpp
@@ -4,14 +4,14 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_empty.hpp>
 #  include <boost/type_traits/is_stateless.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(tricky_abstract_type_test)
 

--- a/test/tricky_add_pointer_test.cpp
+++ b/test/tricky_add_pointer_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/add_pointer.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(add_pointer_test_5, ::tt::add_pointer, const &, const*)
 BOOST_DECL_TRANSFORM_TEST(add_pointer_test_6, ::tt::add_pointer, &, *)

--- a/test/tricky_function_type_test.cpp
+++ b/test/tricky_function_type_test.cpp
@@ -4,8 +4,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
@@ -23,6 +21,8 @@
 #  include <boost/type_traits/is_base_of.hpp>
 #  include <boost/type_traits/is_convertible.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(tricky_function_type_test)
 

--- a/test/tricky_incomplete_type_test.cpp
+++ b/test/tricky_incomplete_type_test.cpp
@@ -4,13 +4,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 TT_TEST_BEGIN(tricky_incomplete_type_test)
 

--- a/test/tricky_is_enum_test.cpp
+++ b/test/tricky_is_enum_test.cpp
@@ -3,13 +3,13 @@
 //  subject to the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/is_enum.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 struct convertible_to_anything
 {

--- a/test/tricky_partial_spec_test.cpp
+++ b/test/tricky_partial_spec_test.cpp
@@ -4,8 +4,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
@@ -23,6 +21,8 @@
 #include <boost/type_traits/is_member_function_pointer.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 #include <stdexcept>
 #include <new>
 #include <exception>

--- a/test/tricky_rvalue_test.cpp
+++ b/test/tricky_rvalue_test.cpp
@@ -4,9 +4,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
-#include <boost/detail/workaround.hpp>
 #ifdef TEST_STD
 #  include <type_traits>
 #else
@@ -16,6 +13,9 @@
 #  include <boost/type_traits/is_reference.hpp>
 #  include <boost/type_traits/is_function.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
+#include <boost/detail/workaround.hpp>
 
 TT_TEST_BEGIN(rvalue_reference_test)
 

--- a/test/type_identity_test.cpp
+++ b/test/type_identity_test.cpp
@@ -5,13 +5,13 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.tt.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_type.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
 #  include <boost/type_traits/type_identity.hpp>
 #endif
+#include "test.hpp"
+#include "check_type.hpp"
 
 BOOST_DECL_TRANSFORM_TEST(type_identity_test_1, ::tt::type_identity, const, const)
 BOOST_DECL_TRANSFORM_TEST(type_identity_test_2, ::tt::type_identity, volatile, volatile)

--- a/test/type_with_alignment_test.cpp
+++ b/test/type_with_alignment_test.cpp
@@ -4,8 +4,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
@@ -13,6 +11,8 @@
 #  include <boost/type_traits/type_with_alignment.hpp>
 #  include <boost/type_traits/is_pod.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 #if defined(BOOST_MSVC) || (defined(BOOST_INTEL) && defined(_MSC_VER))
 #if (_MSC_VER >= 1400) && defined(_M_IX86)

--- a/test/udt_specialisations.cpp
+++ b/test/udt_specialisations.cpp
@@ -4,8 +4,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "test.hpp"
-#include "check_integral_constant.hpp"
 #ifdef TEST_STD
 #  include <type_traits>
 #else
@@ -13,6 +11,8 @@
 #  include <boost/type_traits/is_class.hpp>
 #  include <boost/type_traits/is_union.hpp>
 #endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
 
 struct my_pod{};
 struct my_union


### PR DESCRIPTION
This reorders the includes in the tests to always include the header being tested first, to check for self-sufficiency, then fixes the issues uncovered by that.

Thanks to @apolukhin for the report.