### PR TITLE
Update PGI C++ compiler support

### DIFF
--- a/include/boost/type_traits/is_floating_point.hpp
+++ b/include/boost/type_traits/is_floating_point.hpp
@@ -21,7 +21,8 @@ namespace boost {
    template<> struct is_floating_point<double> : public true_type{};
    template<> struct is_floating_point<long double> : public true_type{};
    
-#if defined(BOOST_HAS_FLOAT128)
+// In PGI x86 compiler, __float128 is a typedef, not its own type.
+#if defined(BOOST_HAS_FLOAT128) && !defined(__PGI)
    template<> struct is_floating_point<__float128> : public true_type{};
 #endif
 


### PR DESCRIPTION
In the PGI C++ compiler, __float128 is a typedef of long double, not its own type.  This causes a duplicate template specialization error when defining is_floating_point<__float128>.  Change the #if expression to not define that specialization when compiling with PGI.