### PR TITLE
Fix 'detail' namespace opening for Borland

### DIFF
--- a/include/boost/type_traits/type_with_alignment.hpp
+++ b/include/boost/type_traits/type_with_alignment.hpp
@@ -76,7 +76,7 @@ template <std::size_t Target> struct short_alignment<Target, false>{ typedef typ
 template <std::size_t Target, bool check> struct char_alignment{ typedef char type; };
 template <std::size_t Target> struct char_alignment<Target, false>{ typedef typename short_alignment<Target, boost::alignment_of<short>::value >= Target>::type type; };
 
-}
+} // namespace detail
 
 template <std::size_t Align>
 struct type_with_alignment 
@@ -213,6 +213,8 @@ template<> struct is_pod< ::boost::tt_align_ns::a128> : public true_type{};
 // 1) The version above doesn't always compile (with the new test cases for example)
 // 2) Because of Borlands #pragma option we can create types with alignments that are
 //    greater that the largest aligned builtin type.
+
+} // namespace detail
 
 namespace tt_align_ns{
 #pragma option push -a16

--- a/include/boost/type_traits/type_with_alignment.hpp
+++ b/include/boost/type_traits/type_with_alignment.hpp
@@ -25,9 +25,8 @@
 #endif
 
 namespace boost {
-   namespace detail{
-
 #ifndef __BORLANDC__
+   namespace detail{
 
       union max_align
       {
@@ -213,8 +212,6 @@ template<> struct is_pod< ::boost::tt_align_ns::a128> : public true_type{};
 // 1) The version above doesn't always compile (with the new test cases for example)
 // 2) Because of Borlands #pragma option we can create types with alignments that are
 //    greater that the largest aligned builtin type.
-
-} // namespace detail
 
 namespace tt_align_ns{
 #pragma option push -a16


### PR DESCRIPTION
In `type_with_alignment.hpp`, the `boost::detail` namespace is opened in line 28 just before starting the main `#ifndef __BORLANDC__`-block at line 30. The `detail` namespace is closed within the `#ifndef`-block at line 79. Highlight that namespace closing-brace with a comment for visibility.

Furthermore, the main `#ifndef __BORLANDC__`-block has a `#else`-case beginning at line 209, which effectively resumes the `boost::detail` namespace at that point. This continuation of the namespace was missing a closing brace, causing a compilation failure with C++Builder (due to not finding `::boost::tt_align_ns::a16` in line 230, but merely finding `::boost::detail::tt_align_ns::a16`). Fix the problem by nesting the `detail` namespace within the `#ifndef __BORLANDC__`-block, to prevent it from leaking into the `#else`-block.