### PR TITLE
Install libstdc++-4.9 for clang 3.8/3.9 14/1z on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -363,6 +363,7 @@ matrix:
         apt:
           packages:
             - clang-3.8
+            - libstdc++-4.9-dev
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.8
@@ -373,6 +374,7 @@ matrix:
         apt:
           packages:
             - clang-3.8
+            - libstdc++-4.9-dev
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.8
@@ -403,6 +405,7 @@ matrix:
         apt:
           packages:
             - clang-3.9
+            - libstdc++-4.9-dev
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.9
@@ -413,6 +416,7 @@ matrix:
         apt:
           packages:
             - clang-3.9
+            - libstdc++-4.9-dev
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.9


### PR DESCRIPTION
This should fix the `::gets` errors caused by the more recent `glibc` on Trusty.