### PR TITLE
Add a workaround for clang 3.0 not supporting decltype in base class list

### DIFF
--- a/include/boost/type_traits/is_nothrow_swappable.hpp
+++ b/include/boost/type_traits/is_nothrow_swappable.hpp
@@ -26,17 +26,21 @@ using std::swap;
 
 template<class T, class U, bool B = noexcept(swap(declval<T>(), declval<U>()))> integral_constant<bool, B> is_nothrow_swappable_with_impl( int );
 template<class T, class U> false_type is_nothrow_swappable_with_impl( ... );
+template<class T, class U>
+struct is_nothrow_swappable_with_helper { typedef decltype( type_traits_swappable_detail::is_nothrow_swappable_with_impl<T, U>(0) ) type; };
 
 template<class T, bool B = noexcept(swap(declval<T&>(), declval<T&>()))> integral_constant<bool, B> is_nothrow_swappable_impl( int );
 template<class T> false_type is_nothrow_swappable_impl( ... );
+template<class T>
+struct is_nothrow_swappable_helper { typedef decltype( type_traits_swappable_detail::is_nothrow_swappable_impl<T>(0) ) type; };
 
 } // namespace type_traits_swappable_detail
 
-template<class T, class U> struct is_nothrow_swappable_with: decltype( type_traits_swappable_detail::is_nothrow_swappable_with_impl<T, U>(0) )
+template<class T, class U> struct is_nothrow_swappable_with: type_traits_swappable_detail::is_nothrow_swappable_with_helper<T, U>::type
 {
 };
 
-template<class T> struct is_nothrow_swappable: decltype( type_traits_swappable_detail::is_nothrow_swappable_impl<T>(0) )
+template<class T> struct is_nothrow_swappable: type_traits_swappable_detail::is_nothrow_swappable_helper<T>::type
 {
 };
 


### PR DESCRIPTION
Use an additional proxy class to define the base class using decltype in a typedef, which is supported by the compiler, judging by Boost.Config tests.

I haven't tested it locally, but I hope it should fix this failure:

http://www.boost.org/development/tests/develop/developer/output/teeks99-02-dc3-0-11-Docker-64on64-boost-bin-v2-libs-type_traits-test-is_nothrow_swappable_test-test-clang-gnu-linux-3-0~c++11-debug.html
