### PR TITLE
Fallback for is_nothrow_swappable on pre-C++11

### DIFF
--- a/doc/is_nothrow_swappable.qbk
+++ b/doc/is_nothrow_swappable.qbk
@@ -1,4 +1,4 @@
-[/ 
+[/
   Copyright 2017 Peter Dimov
 
   Distributed under the Boost Software License, Version 1.0.
@@ -16,7 +16,10 @@ __inherit If the expression `swap(declval<T&>(), declval<T&>())` (in a context
 where `std::swap` is visible) is valid and non-throwing, inherits from
 __true_type, otherwise from __false_type.
 
-__compat This trait requires C++11.
+__compat This trait requires C++11 for full support. Without C++11 it will
+inherit from __true_type for scalar types (including integral, floating point,
+enumeration, pointer and pointer-to-member types), and from __false_type for
+anything else.
 
 __header ` #include <boost/type_traits/is_nothrow_swappable.hpp>` or ` #include <boost/type_traits.hpp>`
 

--- a/include/boost/type_traits/is_nothrow_swappable.hpp
+++ b/include/boost/type_traits/is_nothrow_swappable.hpp
@@ -10,6 +10,20 @@
 #include <boost/config.hpp>
 
 #if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
+
+#include <boost/type_traits/is_scalar.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/integral_constant.hpp>
+
+namespace boost
+{
+template <class T> struct is_nothrow_swappable : boost::integral_constant<bool,
+    boost::is_scalar<T>::value && !boost::is_const<T>::value> {};
+
+template <class T, class U> struct is_nothrow_swappable_with : false_type {};
+template <class T> struct is_nothrow_swappable_with<T, T> : is_nothrow_swappable<T> {};
+}
+
 #else
 
 #include <boost/type_traits/declval.hpp>

--- a/test/is_nothrow_swappable_test.cpp
+++ b/test/is_nothrow_swappable_test.cpp
@@ -13,15 +13,6 @@
 
 #include <boost/config.hpp>
 
-#if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) \
-    || (defined(__GLIBCXX__) && __GLIBCXX__ <= 20120301) // built-in clang++ -std=c++11 on Travis, w/ libstdc++ 4.6
-
-int main()
-{
-}
-
-#else
-
 #include "test.hpp"
 #include "check_integral_constant.hpp"
 #include <utility>
@@ -46,7 +37,13 @@ struct V
     V& operator=( V const& ) { return *this; }
 };
 
-void swap( V&, V& ) noexcept {}
+void swap( V&, V& ) BOOST_NOEXCEPT {}
+
+struct U
+{
+};
+
+void swap(U&, U&) {}
 
 TT_TEST_BEGIN(is_nothrow_swappable)
 
@@ -55,15 +52,48 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const>::value, fals
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int volatile>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const volatile>::value, false);
 
+#if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) \
+    || (defined(__GLIBCXX__) && __GLIBCXX__ <= 20120301) // built-in clang++ -std=c++11 on Travis, w/ libstdc++ 4.6
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const volatile[2]>::value, false);
+#else
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int[2]>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const[2]>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int volatile[2]>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const volatile[2]>::value, false);
+#endif
 
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<void>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<void const>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<void volatile>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<void const volatile>::value, false);
+
+#if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) \
+    || (defined(__GLIBCXX__) && __GLIBCXX__ <= 20120301) // built-in clang++ -std=c++11 on Travis, w/ libstdc++ 4.6
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X const volatile[2]>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<Z>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<Z const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<Z volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<Z const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<U>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<U const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<U volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<U const volatile>::value, false);
+
+#else
 
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X const>::value, false);
@@ -105,6 +135,11 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<V const[2]>::value, fal
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<V volatile[2]>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<V const volatile[2]>::value, false);
 
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<U>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<U const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<U volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<U const volatile>::value, false);
+
 BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<X, int> >::value), true);
 BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<X, int> const>::value), false);
 BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<X, int> volatile>::value), false);
@@ -120,6 +155,6 @@ BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<V, int> cons
 BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<V, int> volatile>::value), false);
 BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<V, int> const volatile>::value), false);
 
-TT_TEST_END
-
 #endif
+
+TT_TEST_END


### PR DESCRIPTION
Add an implementation of is_nothrow_swappable for when C++11 isn't available, as discussed in #40. True for non-const scalar types as I don't think their swaps can ever throw, and false_for everything else.

Boost.Move's implementation uses `is_empty<T>::value || is_pod<T>::value` which is probably reasonable, but custom types might have an overloaded swap which is not `noexcept`, so that would be true in C++03, and false in C++11, which seems wrong to me.