### PR TITLE
Add container_hash to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,7 @@ install:
   - git submodule update --init libs/type_index
   - git submodule update --init libs/utility
   - git submodule update --init libs/functional
+  - git submodule update --init libs/container_hash
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\type_traits
   - bootstrap
   - b2 headers


### PR DESCRIPTION
The hash headers are now in this module, not functional, so you might not need
functional any more. Travis doesn't use the functional submodule, so it
presumably does not need this module either.