### PR TITLE
Assert when we try to use an incomplete type on a trait which require…

### DIFF
--- a/doc/html/boost_typetraits/reference.html
+++ b/doc/html/boost_typetraits/reference.html
@@ -108,6 +108,7 @@
 <dt><span class="section"><a href="reference/is_assignable.html">is_assignable</a></span></dt>
 <dt><span class="section"><a href="reference/is_base_of.html">is_base_of</a></span></dt>
 <dt><span class="section"><a href="reference/is_class.html">is_class</a></span></dt>
+<dt><span class="section"><a href="reference/is_complete.html">is_complete</a></span></dt>
 <dt><span class="section"><a href="reference/is_complex.html">is_complex</a></span></dt>
 <dt><span class="section"><a href="reference/is_compound.html">is_compound</a></span></dt>
 <dt><span class="section"><a href="reference/is_const.html">is_const</a></span></dt>

--- a/doc/html/boost_typetraits/reference/is_class.html
+++ b/doc/html/boost_typetraits/reference/is_class.html
@@ -7,7 +7,7 @@
 <link rel="home" href="../../index.html" title="Chapter&#160;1.&#160;Boost.TypeTraits">
 <link rel="up" href="../reference.html" title="Alphabetical Reference">
 <link rel="prev" href="is_base_of.html" title="is_base_of">
-<link rel="next" href="is_complex.html" title="is_complex">
+<link rel="next" href="is_complete.html" title="is_complete">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <table cellpadding="2" width="100%"><tr>
@@ -20,7 +20,7 @@
 </tr></table>
 <hr>
 <div class="spirit-nav">
-<a accesskey="p" href="is_base_of.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_complex.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
+<a accesskey="p" href="is_base_of.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_complete.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h3 class="title">
@@ -93,7 +93,7 @@
 </tr></table>
 <hr>
 <div class="spirit-nav">
-<a accesskey="p" href="is_base_of.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_complex.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
+<a accesskey="p" href="is_base_of.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_complete.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
 </div>
 </body>
 </html>

--- a/doc/html/boost_typetraits/reference/is_complete.html
+++ b/doc/html/boost_typetraits/reference/is_complete.html
@@ -1,0 +1,79 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
+<title>is_complete</title>
+<link rel="stylesheet" href="../../../../../../doc/src/boostbook.css" type="text/css">
+<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<link rel="home" href="../../index.html" title="Chapter&#160;1.&#160;Boost.TypeTraits">
+<link rel="up" href="../reference.html" title="Alphabetical Reference">
+<link rel="prev" href="is_class.html" title="is_class">
+<link rel="next" href="is_complex.html" title="is_complex">
+</head>
+<body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
+<table cellpadding="2" width="100%"><tr>
+<td valign="top"><img alt="Boost C++ Libraries" width="277" height="86" src="../../../../../../boost.png"></td>
+<td align="center"><a href="../../../../../../index.html">Home</a></td>
+<td align="center"><a href="../../../../../../libs/libraries.htm">Libraries</a></td>
+<td align="center"><a href="http://www.boost.org/users/people.html">People</a></td>
+<td align="center"><a href="http://www.boost.org/users/faq.html">FAQ</a></td>
+<td align="center"><a href="../../../../../../more/index.htm">More</a></td>
+</tr></table>
+<hr>
+<div class="spirit-nav">
+<a accesskey="p" href="is_class.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_complex.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
+</div>
+<div class="section">
+<div class="titlepage"><div><div><h3 class="title">
+<a name="boost_typetraits.reference.is_complete"></a><a class="link" href="is_complete.html" title="is_complete">is_complete</a>
+</h3></div></div></div>
+<pre class="programlisting"><span class="keyword">template</span> <span class="special">&lt;</span><span class="keyword">class</span> <span class="identifier">T</span><span class="special">&gt;</span>
+<span class="keyword">struct</span> <span class="identifier">is_complete</span> <span class="special">:</span> <span class="keyword">public</span> <em class="replaceable"><code><a class="link" href="integral_constant.html" title="integral_constant">true_type</a>-or-<a class="link" href="integral_constant.html" title="integral_constant">false_type</a></code></em> <span class="special">{};</span>
+</pre>
+<p>
+        <span class="bold"><strong>Inherits:</strong></span> If <code class="computeroutput"><span class="identifier">T</span></code>
+        is a complete type then inherits from <a class="link" href="integral_constant.html" title="integral_constant">true_type</a>,
+        otherwise inherits from <a class="link" href="integral_constant.html" title="integral_constant">false_type</a>.
+      </p>
+<div class="important"><table border="0" summary="Important">
+<tr>
+<td rowspan="2" align="center" valign="top" width="25"><img alt="[Important]" src="../../../../../../doc/src/images/important.png"></td>
+<th align="left">Important</th>
+</tr>
+<tr><td align="left" valign="top"><p>
+          This trait is designed for one use only: to trigger a hard error (via a
+          <code class="computeroutput"><span class="keyword">static_assert</span></code>) when a template
+          is accidentally instantiated on an incomplete type. Any other use case
+          will cause ODR violations as the "completeness" of type <code class="computeroutput"><span class="identifier">T</span></code> may vary at different points in the
+          current translation unit, as well as across translations units. <span class="emphasis"><em><span class="bold"><strong>In particular this trait should never ever be used to change
+          code paths depending on the completeness of a type</strong></span></em></span>.
+        </p></td></tr>
+</table></div>
+<p>
+        <span class="bold"><strong>Header:</strong></span> <code class="computeroutput"> <span class="preprocessor">#include</span>
+        <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">type_traits</span><span class="special">/</span><span class="identifier">is_complete</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span></code>
+        or <code class="computeroutput"> <span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">type_traits</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span></code>
+      </p>
+<p>
+        <span class="bold"><strong>Compiler Compatibility:</strong></span> Requires C++11 SFINAE-expressions
+        to function fully. The macro <code class="computeroutput"><span class="identifier">BOOST_TT_HAS_WORKING_IS_COMPLETE</span></code>
+        is defined when the trait is fully functional.
+      </p>
+</div>
+<table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
+<td align="left"></td>
+<td align="right"><div class="copyright-footer">Copyright &#169; 2000, 2011 Adobe Systems Inc, David Abrahams,
+      Frederic Bron, Steve Cleary, Beman Dawes, Aleksey Gurtovoy, Howard Hinnant,
+      Jesse Jones, Mat Marcus, Itay Maman, John Maddock, Alexander Nasonov, Thorsten
+      Ottosen, Roman Perepelitsa, Robert Ramey, Jeremy Siek, Robert Stewart and Steven
+      Watanabe<p>
+        Distributed under the Boost Software License, Version 1.0. (See accompanying
+        file LICENSE_1_0.txt or copy at <a href="http://www.boost.org/LICENSE_1_0.txt" target="_top">http://www.boost.org/LICENSE_1_0.txt</a>)
+      </p>
+</div></td>
+</tr></table>
+<hr>
+<div class="spirit-nav">
+<a accesskey="p" href="is_class.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_complex.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
+</div>
+</body>
+</html>

--- a/doc/html/boost_typetraits/reference/is_complex.html
+++ b/doc/html/boost_typetraits/reference/is_complex.html
@@ -6,7 +6,7 @@
 <meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
 <link rel="home" href="../../index.html" title="Chapter&#160;1.&#160;Boost.TypeTraits">
 <link rel="up" href="../reference.html" title="Alphabetical Reference">
-<link rel="prev" href="is_class.html" title="is_class">
+<link rel="prev" href="is_complete.html" title="is_complete">
 <link rel="next" href="is_compound.html" title="is_compound">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
@@ -20,7 +20,7 @@
 </tr></table>
 <hr>
 <div class="spirit-nav">
-<a accesskey="p" href="is_class.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_compound.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
+<a accesskey="p" href="is_complete.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_compound.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h3 class="title">
@@ -62,7 +62,7 @@
 </tr></table>
 <hr>
 <div class="spirit-nav">
-<a accesskey="p" href="is_class.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_compound.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
+<a accesskey="p" href="is_complete.html"><img src="../../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../reference.html"><img src="../../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../../index.html"><img src="../../../../../../doc/src/images/home.png" alt="Home"></a><a accesskey="n" href="is_compound.html"><img src="../../../../../../doc/src/images/next.png" alt="Next"></a>
 </div>
 </body>
 </html>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -164,6 +164,7 @@
 <dt><span class="section"><a href="boost_typetraits/reference/is_assignable.html">is_assignable</a></span></dt>
 <dt><span class="section"><a href="boost_typetraits/reference/is_base_of.html">is_base_of</a></span></dt>
 <dt><span class="section"><a href="boost_typetraits/reference/is_class.html">is_class</a></span></dt>
+<dt><span class="section"><a href="boost_typetraits/reference/is_complete.html">is_complete</a></span></dt>
 <dt><span class="section"><a href="boost_typetraits/reference/is_complex.html">is_complex</a></span></dt>
 <dt><span class="section"><a href="boost_typetraits/reference/is_compound.html">is_compound</a></span></dt>
 <dt><span class="section"><a href="boost_typetraits/reference/is_const.html">is_const</a></span></dt>

--- a/doc/html/index/s11.html
+++ b/doc/html/index/s11.html
@@ -24,7 +24,7 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="id1652848"></a>Class Index</h2></div></div></div>
+<a name="id1670677"></a>Class Index</h2></div></div></div>
 <p><a class="link" href="s11.html#idx_id_0">A</a> <a class="link" href="s11.html#idx_id_2">C</a> <a class="link" href="s11.html#idx_id_3">D</a> <a class="link" href="s11.html#idx_id_4">E</a> <a class="link" href="s11.html#idx_id_5">F</a> <a class="link" href="s11.html#idx_id_6">H</a> <a class="link" href="s11.html#idx_id_7">I</a> <a class="link" href="s11.html#idx_id_8">M</a> <a class="link" href="s11.html#idx_id_9">N</a> <a class="link" href="s11.html#idx_id_10">O</a> <a class="link" href="s11.html#idx_id_11">P</a> <a class="link" href="s11.html#idx_id_12">R</a> <a class="link" href="s11.html#idx_id_13">T</a></p>
 <div class="variablelist"><dl class="variablelist">
 <dt>
@@ -232,6 +232,7 @@
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/user_defined.html" title="User Defined Specializations"><span class="index-entry-level-1">User Defined Specializations</span></a></p></li>
 </ul></div>
 </li>
+<li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_complete.html" title="is_complete"><span class="index-entry-level-0">is_complete</span></a></p></li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_complex.html" title="is_complex"><span class="index-entry-level-0">is_complex</span></a></p></li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_compound.html" title="is_compound"><span class="index-entry-level-0">is_compound</span></a></p></li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_const.html" title="is_const"><span class="index-entry-level-0">is_const</span></a></p></li>

--- a/doc/html/index/s12.html
+++ b/doc/html/index/s12.html
@@ -24,7 +24,7 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="id1657318"></a>Typedef Index</h2></div></div></div>
+<a name="id1672702"></a>Typedef Index</h2></div></div></div>
 <p><a class="link" href="s12.html#idx_id_21">F</a> <a class="link" href="s12.html#idx_id_28">R</a> <a class="link" href="s12.html#idx_id_29">T</a> <a class="link" href="s12.html#idx_id_31">V</a></p>
 <div class="variablelist"><dl class="variablelist">
 <dt>

--- a/doc/html/index/s13.html
+++ b/doc/html/index/s13.html
@@ -24,7 +24,7 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="id1657546"></a>Macro Index</h2></div></div></div>
+<a name="id1672913"></a>Macro Index</h2></div></div></div>
 <p><a class="link" href="s13.html#idx_id_33">B</a></p>
 <div class="variablelist"><dl class="variablelist">
 <dt>
@@ -166,6 +166,10 @@
 <li class="listitem" style="list-style-type: none">
 <p><span class="index-entry-level-0">BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION</span></p>
 <div class="index"><ul class="index" style="list-style-type: none; "><li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_class.html" title="is_class"><span class="index-entry-level-1">is_class</span></a></p></li></ul></div>
+</li>
+<li class="listitem" style="list-style-type: none">
+<p><span class="index-entry-level-0">BOOST_TT_HAS_WORKING_IS_COMPLETE</span></p>
+<div class="index"><ul class="index" style="list-style-type: none; "><li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_complete.html" title="is_complete"><span class="index-entry-level-1">is_complete</span></a></p></li></ul></div>
 </li>
 <li class="listitem" style="list-style-type: none">
 <p><span class="index-entry-level-0">BOOST_TT_IS_CONSTRUCTIBLE_CONFORMING</span></p>

--- a/doc/html/index/s14.html
+++ b/doc/html/index/s14.html
@@ -23,7 +23,7 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="id1655963"></a>Index</h2></div></div></div>
+<a name="id1673613"></a>Index</h2></div></div></div>
 <p><a class="link" href="s14.html#idx_id_48">A</a> <a class="link" href="s14.html#idx_id_49">B</a> <a class="link" href="s14.html#idx_id_50">C</a> <a class="link" href="s14.html#idx_id_51">D</a> <a class="link" href="s14.html#idx_id_52">E</a> <a class="link" href="s14.html#idx_id_53">F</a> <a class="link" href="s14.html#idx_id_54">H</a> <a class="link" href="s14.html#idx_id_55">I</a> <a class="link" href="s14.html#idx_id_56">M</a> <a class="link" href="s14.html#idx_id_57">N</a> <a class="link" href="s14.html#idx_id_58">O</a> <a class="link" href="s14.html#idx_id_59">P</a> <a class="link" href="s14.html#idx_id_60">R</a> <a class="link" href="s14.html#idx_id_61">T</a> <a class="link" href="s14.html#idx_id_62">U</a> <a class="link" href="s14.html#idx_id_63">V</a></p>
 <div class="variablelist"><dl class="variablelist">
 <dt>
@@ -199,6 +199,10 @@
 <div class="index"><ul class="index" style="list-style-type: none; "><li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_class.html" title="is_class"><span class="index-entry-level-1">is_class</span></a></p></li></ul></div>
 </li>
 <li class="listitem" style="list-style-type: none">
+<p><span class="index-entry-level-0">BOOST_TT_HAS_WORKING_IS_COMPLETE</span></p>
+<div class="index"><ul class="index" style="list-style-type: none; "><li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_complete.html" title="is_complete"><span class="index-entry-level-1">is_complete</span></a></p></li></ul></div>
+</li>
+<li class="listitem" style="list-style-type: none">
 <p><span class="index-entry-level-0">BOOST_TT_IS_CONSTRUCTIBLE_CONFORMING</span></p>
 <div class="index"><ul class="index" style="list-style-type: none; "><li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_constructible.html" title="is_constructible"><span class="index-entry-level-1">is_constructible</span></a></p></li></ul></div>
 </li>
@@ -207,6 +211,10 @@
 <a name="idx_id_50"></a><span class="term">C</span>
 </dt>
 <dd><div class="index"><ul class="index" style="list-style-type: none; ">
+<li class="listitem" style="list-style-type: none">
+<p><span class="index-entry-level-0">check</span></p>
+<div class="index"><ul class="index" style="list-style-type: none; "><li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/category/value_traits/operators.html" title="Operator Type Traits"><span class="index-entry-level-1">Operator Type Traits</span></a></p></li></ul></div>
+</li>
 <li class="listitem" style="list-style-type: none">
 <p><span class="index-entry-level-0">common_type</span></p>
 <div class="index"><ul class="index" style="list-style-type: none; ">
@@ -734,6 +742,13 @@
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/user_defined.html" title="User Defined Specializations"><span class="index-entry-level-1">User Defined Specializations</span></a></p></li>
 </ul></div>
 </li>
+<li class="listitem" style="list-style-type: none">
+<p><span class="index-entry-level-0">is_complete</span></p>
+<div class="index"><ul class="index" style="list-style-type: none; ">
+<li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_complete.html" title="is_complete"><span class="index-entry-level-1">BOOST_TT_HAS_WORKING_IS_COMPLETE</span></a></p></li>
+<li class="listitem" style="list-style-type: none"><p><span class="bold"><strong><a class="link" href="../boost_typetraits/reference/is_complete.html" title="is_complete"><span class="index-entry-level-1">is_complete</span></a></strong></span></p></li>
+</ul></div>
+</li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_complex.html" title="is_complex"><span class="index-entry-level-0">is_complex</span></a></p></li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_compound.html" title="is_compound"><span class="index-entry-level-0">is_compound</span></a></p></li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/reference/is_const.html" title="is_const"><span class="index-entry-level-0">is_const</span></a></p></li>
@@ -871,6 +886,7 @@
 <p><span class="index-entry-level-0">Operator Type Traits</span></p>
 <div class="index"><ul class="index" style="list-style-type: none; ">
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/category/value_traits/operators.html" title="Operator Type Traits"><span class="index-entry-level-1">any</span></a></p></li>
+<li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/category/value_traits/operators.html" title="Operator Type Traits"><span class="index-entry-level-1">check</span></a></p></li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/category/value_traits/operators.html" title="Operator Type Traits"><span class="index-entry-level-1">dont_care</span></a></p></li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/category/value_traits/operators.html" title="Operator Type Traits"><span class="index-entry-level-1">has_equal_to</span></a></p></li>
 <li class="listitem" style="list-style-type: none"><p><a class="link" href="../boost_typetraits/category/value_traits/operators.html" title="Operator Type Traits"><span class="index-entry-level-1">has_operator</span></a></p></li>

--- a/doc/is_complete.qbk
+++ b/doc/is_complete.qbk
@@ -1,0 +1,29 @@
+[/ 
+  Copyright 2018 John Maddock.
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt).
+]
+
+[section:is_complete is_complete]
+
+   template <class T>
+   struct is_complete : public __tof {};
+  
+__inherit If `T` is a complete type then inherits from __true_type, 
+otherwise inherits from __false_type.
+
+[important This trait is designed for one use only: to trigger a hard error (via a `static_assert`) when a template
+is accidentally instantiated on an incomplete type.  Any other use case will cause ODR violations as the "completeness"
+of type `T` may vary at different points in the current translation unit, as well as across translations units.
+['[*In particular this trait should never ever be used to change code paths depending on the completeness of a type]].]
+
+__header ` #include <boost/type_traits/is_complete.hpp>` or ` #include <boost/type_traits.hpp>`
+
+__compat Requires C++11 SFINAE-expressions to function fully.  The macro `BOOST_TT_HAS_WORKING_IS_COMPLETE` is defined
+when the trait is fully functional.
+
+[endsect]
+
+
+

--- a/doc/type_traits.qbk
+++ b/doc/type_traits.qbk
@@ -291,6 +291,7 @@ See __has_trivial_constructor.
 [include is_assignable.qbk]
 [include is_base_of.qbk]
 [include is_class.qbk]
+[include is_complete.qbk]
 [include is_complex.qbk]
 [include is_compound.qbk]
 [include is_const.qbk]

--- a/include/boost/type_traits/common_type.hpp
+++ b/include/boost/type_traits/common_type.hpp
@@ -13,6 +13,10 @@
 #include <boost/type_traits/decay.hpp>
 #include <boost/type_traits/declval.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/type_traits/is_void.hpp>
+#include <boost/type_traits/is_array.hpp>
+#include <boost/static_assert.hpp>
 
 #if defined(BOOST_NO_CXX11_DECLTYPE)
 #include <boost/type_traits/detail/common_type_impl.hpp>
@@ -75,6 +79,7 @@ struct common_type: common_type<typename common_type<T1, T2>::type, T3, T4, T5, 
 
 template<class T> struct common_type<T>: boost::decay<T>
 {
+   BOOST_STATIC_ASSERT_MSG(::boost::is_complete<T>::value || ::boost::is_void<T>::value || ::boost::is_array<T>::value, "Arguments to common_type must both be complete types");
 };
 
 // two arguments
@@ -138,6 +143,8 @@ template<class T1, class T2> struct common_type_decay_helper<T1, T2, T1, T2>: co
 
 template<class T1, class T2> struct common_type<T1, T2>: type_traits_detail::common_type_decay_helper<T1, T2>
 {
+   BOOST_STATIC_ASSERT_MSG(::boost::is_complete<T1>::value || ::boost::is_void<T1>::value || ::boost::is_array<T1>::value, "Arguments to common_type must both be complete types");
+   BOOST_STATIC_ASSERT_MSG(::boost::is_complete<T2>::value || ::boost::is_void<T2>::value || ::boost::is_array<T2>::value, "Arguments to common_type must both be complete types");
 };
 
 } // namespace boost

--- a/include/boost/type_traits/has_nothrow_destructor.hpp
+++ b/include/boost/type_traits/has_nothrow_destructor.hpp
@@ -15,6 +15,8 @@
 
 #include <boost/type_traits/declval.hpp>
 #include <boost/type_traits/is_destructible.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/static_assert.hpp>
 
 namespace boost{
 
@@ -27,12 +29,19 @@ namespace boost{
 
    }
 
-   template <class T> struct has_nothrow_destructor : public detail::has_nothrow_destructor_imp<T, boost::is_destructible<T>::value>{};
-   template <class T, std::size_t N> struct has_nothrow_destructor<T[N]> : public has_nothrow_destructor<T>{};
+   template <class T> struct has_nothrow_destructor : public detail::has_nothrow_destructor_imp<T, boost::is_destructible<T>::value>
+   {
+      BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to has_nothrow_destructor must be complete types");
+   };
+   template <class T, std::size_t N> struct has_nothrow_destructor<T[N]> : public has_nothrow_destructor<T>
+   {
+      BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to has_nothrow_destructor must be complete types");
+   };
    template <class T> struct has_nothrow_destructor<T&> : public integral_constant<bool, false>{};
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) 
    template <class T> struct has_nothrow_destructor<T&&> : public integral_constant<bool, false>{};
 #endif
+   template <> struct has_nothrow_destructor<void> : public false_type {};
 }
 #else
 

--- a/include/boost/type_traits/is_assignable.hpp
+++ b/include/boost/type_traits/is_assignable.hpp
@@ -12,6 +12,8 @@
 #include <cstddef> // size_t
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/static_assert.hpp>
 
 namespace boost{
 
@@ -39,7 +41,10 @@ namespace boost{
 
    }
 
-   template <class T, class U> struct is_assignable : public integral_constant<bool, sizeof(detail::is_assignable_imp::test<T, U>(0)) == sizeof(boost::type_traits::yes_type)>{};
+   template <class T, class U> struct is_assignable : public integral_constant<bool, sizeof(detail::is_assignable_imp::test<T, U>(0)) == sizeof(boost::type_traits::yes_type)>
+   {
+      BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_assignable must be complete types");
+   };
    template <class T, std::size_t N, class U> struct is_assignable<T[N], U> : public is_assignable<T, U>{};
    template <class T, std::size_t N, class U> struct is_assignable<T(&)[N], U> : public is_assignable<T&, U>{};
    template <class T, class U> struct is_assignable<T[], U> : public is_assignable<T, U>{};
@@ -57,7 +62,10 @@ namespace boost{
 namespace boost{
 
    // We don't know how to implement this:
-   template <class T, class U> struct is_assignable : public integral_constant<bool, false>{};
+   template <class T, class U> struct is_assignable : public integral_constant<bool, false>
+   {
+      BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_assignable must be complete types");
+   };
    template <class T, class U> struct is_assignable<T&, U> : public integral_constant<bool, is_pod<T>::value && is_pod<typename remove_reference<U>::type>::value>{};
    template <class T, class U> struct is_assignable<const T&, U> : public integral_constant<bool, false>{};
    template <class U> struct is_assignable<void, U> : public integral_constant<bool, false>{};

--- a/include/boost/type_traits/is_complete.hpp
+++ b/include/boost/type_traits/is_complete.hpp
@@ -27,6 +27,12 @@
 
 namespace boost {
 
+
+//
+// We will undef this if the trait isn't fully functional:
+//
+#define BOOST_TT_HAS_WORKING_IS_COMPLETE
+
 #if !defined(BOOST_NO_SFINAE_EXPR) && !BOOST_WORKAROUND(BOOST_MSVC, <= 1900)
 
    namespace detail{
@@ -73,6 +79,8 @@ namespace boost {
 
       template <class T> struct is_complete
          : public integral_constant<bool, true> {};
+
+#undef BOOST_TT_HAS_WORKING_IS_COMPLETE
 
 #endif
 

--- a/include/boost/type_traits/is_complete.hpp
+++ b/include/boost/type_traits/is_complete.hpp
@@ -27,7 +27,7 @@
 
 namespace boost {
 
-#ifndef BOOST_NO_SFINAE_EXPR
+#if !defined(BOOST_NO_SFINAE_EXPR) && !BOOST_WORKAROUND(BOOST_MSVC, <= 1900)
 
    namespace detail{
 
@@ -43,7 +43,7 @@ namespace boost {
    template <class T> struct is_complete
       : public integral_constant<bool, ::boost::is_function<typename boost::remove_reference<T>::type>::value || (sizeof(detail::check_is_complete<T>(0)) != sizeof(char))> {};
 
-#elif !defined(BOOST_NO_SFINAE)
+#elif !defined(BOOST_NO_SFINAE) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
 
    namespace detail
    {

--- a/include/boost/type_traits/is_constructible.hpp
+++ b/include/boost/type_traits/is_constructible.hpp
@@ -18,6 +18,8 @@
 #include <boost/type_traits/is_default_constructible.hpp>
 #include <boost/type_traits/detail/yes_no_type.hpp>
 #include <boost/type_traits/declval.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/static_assert.hpp>
 
 #define BOOST_TT_IS_CONSTRUCTIBLE_CONFORMING 1
 
@@ -45,8 +47,14 @@ namespace boost{
 
    }
 
-   template <class T, class ...Args> struct is_constructible : public integral_constant<bool, sizeof(detail::is_constructible_imp::test<T, Args...>(0)) == sizeof(boost::type_traits::yes_type)>{};
-   template <class T, class Arg> struct is_constructible<T, Arg> : public integral_constant<bool, is_destructible<T>::value && sizeof(detail::is_constructible_imp::test1<T, Arg>(0)) == sizeof(boost::type_traits::yes_type)>{};
+   template <class T, class ...Args> struct is_constructible : public integral_constant<bool, sizeof(detail::is_constructible_imp::test<T, Args...>(0)) == sizeof(boost::type_traits::yes_type)>
+   {
+      BOOST_STATIC_ASSERT_MSG(::boost::is_complete<T>::value, "The target type must be complete in order to test for constructibility");
+   };
+   template <class T, class Arg> struct is_constructible<T, Arg> : public integral_constant<bool, is_destructible<T>::value && sizeof(detail::is_constructible_imp::test1<T, Arg>(0)) == sizeof(boost::type_traits::yes_type)>
+   {
+      BOOST_STATIC_ASSERT_MSG(::boost::is_complete<T>::value, "The target type must be complete in order to test for constructibility");
+   };
    template <class Ref, class Arg> struct is_constructible<Ref&, Arg> : public integral_constant<bool, sizeof(detail::is_constructible_imp::ref_test<Ref&>(boost::declval<Arg>())) == sizeof(boost::type_traits::yes_type)>{};
    template <class Ref, class Arg> struct is_constructible<Ref&&, Arg> : public integral_constant<bool, sizeof(detail::is_constructible_imp::ref_test<Ref&&>(boost::declval<Arg>())) == sizeof(boost::type_traits::yes_type)>{};
 

--- a/include/boost/type_traits/is_convertible.hpp
+++ b/include/boost/type_traits/is_convertible.hpp
@@ -14,11 +14,11 @@
 
 #include <boost/type_traits/intrinsics.hpp>
 #include <boost/type_traits/integral_constant.hpp>
-#ifndef BOOST_IS_CONVERTIBLE
 #include <boost/type_traits/is_complete.hpp>
 #include <boost/type_traits/is_void.hpp>
 #include <boost/type_traits/is_array.hpp>
 #include <boost/static_assert.hpp>
+#ifndef BOOST_IS_CONVERTIBLE
 #include <boost/type_traits/detail/yes_no_type.hpp>
 #include <boost/type_traits/detail/config.hpp>
 #include <boost/type_traits/is_array.hpp>
@@ -487,7 +487,14 @@ struct is_convertible : public integral_constant<bool, ::boost::detail::is_conve
 #else
 
 template <class From, class To>
-struct is_convertible : public integral_constant<bool, BOOST_IS_CONVERTIBLE(From, To)> {};
+struct is_convertible : public integral_constant<bool, BOOST_IS_CONVERTIBLE(From, To)> 
+{
+#ifdef __clang__
+   // clang's intrinsic doesn't assert on incomplete types:
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<To>::value || boost::is_void<To>::value || boost::is_array<To>::value, "Destination argument type to is_convertible must be a complete type");
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<From>::value || boost::is_void<From>::value || boost::is_array<From>::value, "From argument type to is_convertible must be a complete type");
+#endif
+};
 
 #endif
 

--- a/include/boost/type_traits/is_convertible.hpp
+++ b/include/boost/type_traits/is_convertible.hpp
@@ -15,6 +15,10 @@
 #include <boost/type_traits/intrinsics.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #ifndef BOOST_IS_CONVERTIBLE
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/type_traits/is_void.hpp>
+#include <boost/type_traits/is_array.hpp>
+#include <boost/static_assert.hpp>
 #include <boost/type_traits/detail/yes_no_type.hpp>
 #include <boost/type_traits/detail/config.hpp>
 #include <boost/type_traits/is_array.hpp>
@@ -474,7 +478,11 @@ template <class From> struct is_convertible_impl_dispatch<From, void volatile> :
 } // namespace detail
 
 template <class From, class To> 
-struct is_convertible : public integral_constant<bool, ::boost::detail::is_convertible_impl_dispatch<From, To>::value> {};
+struct is_convertible : public integral_constant<bool, ::boost::detail::is_convertible_impl_dispatch<From, To>::value> 
+{
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<To>::value || boost::is_void<To>::value || boost::is_array<To>::value, "Destination argument type to is_convertible must be a complete type");
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<From>::value || boost::is_void<From>::value || boost::is_array<From>::value, "From argument type to is_convertible must be a complete type");
+};
 
 #else
 

--- a/include/boost/type_traits/is_convertible.hpp
+++ b/include/boost/type_traits/is_convertible.hpp
@@ -489,7 +489,10 @@ struct is_convertible : public integral_constant<bool, ::boost::detail::is_conve
 template <class From, class To>
 struct is_convertible : public integral_constant<bool, BOOST_IS_CONVERTIBLE(From, To)> 
 {
-#ifdef __clang__
+#if BOOST_WORKAROUND(BOOST_MSVC, <= 1900)
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<From>::value || boost::is_void<From>::value || boost::is_array<From>::value || boost::is_reference<From>::value, "From argument type to is_convertible must be a complete type");
+#endif
+#if defined(__clang__)
    // clang's intrinsic doesn't assert on incomplete types:
    BOOST_STATIC_ASSERT_MSG(boost::is_complete<To>::value || boost::is_void<To>::value || boost::is_array<To>::value, "Destination argument type to is_convertible must be a complete type");
    BOOST_STATIC_ASSERT_MSG(boost::is_complete<From>::value || boost::is_void<From>::value || boost::is_array<From>::value, "From argument type to is_convertible must be a complete type");

--- a/include/boost/type_traits/is_default_constructible.hpp
+++ b/include/boost/type_traits/is_default_constructible.hpp
@@ -12,6 +12,8 @@
 #include <cstddef> // size_t
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/static_assert.hpp>
 
 #if BOOST_WORKAROUND(BOOST_GCC_VERSION, < 40700)
 #include <boost/type_traits/is_abstract.hpp>
@@ -51,9 +53,15 @@ namespace boost{
    }
 
 #if BOOST_WORKAROUND(BOOST_GCC_VERSION, < 40700)
-   template <class T> struct is_default_constructible : public integral_constant<bool, detail::is_default_constructible_abstract_filter<T, boost::is_abstract<T>::value>::value>{};
+   template <class T> struct is_default_constructible : public integral_constant<bool, detail::is_default_constructible_abstract_filter<T, boost::is_abstract<T>::value>::value>
+   {
+      BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_default_constructible must be complete types");
+   };
 #else
-   template <class T> struct is_default_constructible : public integral_constant<bool, sizeof(detail::is_default_constructible_imp::test<T>(0)) == sizeof(boost::type_traits::yes_type)>{};
+   template <class T> struct is_default_constructible : public integral_constant<bool, sizeof(detail::is_default_constructible_imp::test<T>(0)) == sizeof(boost::type_traits::yes_type)>
+   {
+      BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_default_constructible must be complete types");
+   };
 #endif
    template <class T, std::size_t N> struct is_default_constructible<T[N]> : public is_default_constructible<T>{};
    template <class T> struct is_default_constructible<T[]> : public is_default_constructible<T>{};

--- a/include/boost/type_traits/is_destructible.hpp
+++ b/include/boost/type_traits/is_destructible.hpp
@@ -12,6 +12,8 @@
 #include <cstddef> // size_t
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/static_assert.hpp>
 
 #if !defined(BOOST_NO_CXX11_DECLTYPE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
 
@@ -32,7 +34,10 @@ namespace boost{
 
    }
 
-   template <class T> struct is_destructible : public integral_constant<bool, sizeof(detail::is_destructible_imp::test<T>(0)) == sizeof(boost::type_traits::yes_type)>{};
+   template <class T> struct is_destructible : public integral_constant<bool, sizeof(detail::is_destructible_imp::test<T>(0)) == sizeof(boost::type_traits::yes_type)>
+   {
+      BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_destructible must be complete types");
+   };
 
 #else
 
@@ -42,7 +47,10 @@ namespace boost{
 namespace boost{
 
    // We don't know how to implement this:
-   template <class T> struct is_destructible : public integral_constant<bool, is_pod<T>::value || is_class<T>::value>{};
+   template <class T> struct is_destructible : public integral_constant<bool, is_pod<T>::value || is_class<T>::value>
+   {
+      BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_destructible must be complete types");
+   };
 #endif
 
    template <> struct is_destructible<void> : public false_type{};

--- a/include/boost/type_traits/is_list_constructible.hpp
+++ b/include/boost/type_traits/is_list_constructible.hpp
@@ -10,6 +10,8 @@
 #include <boost/config.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/declval.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/static_assert.hpp>
 
 namespace boost
 {
@@ -18,6 +20,7 @@ namespace boost
 
 template<class T, class = void, class = void, class = void, class = void, class = void, class = void> struct is_list_constructible: false_type
 {
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_list_constructible must be complete types");
 };
 
 #else
@@ -32,6 +35,7 @@ template<class T, class... A> false_type is_list_constructible_impl( ... );
 
 template<class T, class... A> struct is_list_constructible: decltype( type_traits_detail::is_list_constructible_impl<T, A...>(0) )
 {
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_list_constructible must be complete types");
 };
 
 #endif

--- a/include/boost/type_traits/is_nothrow_move_assignable.hpp
+++ b/include/boost/type_traits/is_nothrow_move_assignable.hpp
@@ -18,13 +18,18 @@
 #include <boost/type_traits/is_reference.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/declval.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/static_assert.hpp>
 
 namespace boost {
 
 #ifdef BOOST_IS_NOTHROW_MOVE_ASSIGN
 
 template <class T>
-struct is_nothrow_move_assignable : public integral_constant<bool, BOOST_IS_NOTHROW_MOVE_ASSIGN(T)>{};
+struct is_nothrow_move_assignable : public integral_constant<bool, BOOST_IS_NOTHROW_MOVE_ASSIGN(T)>
+{
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_nothrow_move_assignable must be complete types");
+};
 template <class T> struct is_nothrow_move_assignable<T const> : public false_type{};
 template <class T> struct is_nothrow_move_assignable<T volatile> : public false_type{};
 template <class T> struct is_nothrow_move_assignable<T const volatile> : public false_type{};
@@ -50,7 +55,10 @@ struct false_or_cpp11_noexcept_move_assignable <
 }
 
 template <class T>
-struct is_nothrow_move_assignable : public integral_constant<bool, ::boost::detail::false_or_cpp11_noexcept_move_assignable<T>::value>{};
+struct is_nothrow_move_assignable : public integral_constant<bool, ::boost::detail::false_or_cpp11_noexcept_move_assignable<T>::value>
+{
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_nothrow_move_assignable must be complete types");
+};
 
 template <class T> struct is_nothrow_move_assignable<T const> : public ::boost::false_type {};
 template <class T> struct is_nothrow_move_assignable<T const volatile> : public ::boost::false_type{};
@@ -64,7 +72,10 @@ template <class T> struct is_nothrow_move_assignable<T&&> : public ::boost::fals
 
 template <class T>
 struct is_nothrow_move_assignable : public integral_constant<bool,
-   (::boost::has_trivial_move_assign<T>::value || ::boost::has_nothrow_assign<T>::value) &&  ! ::boost::is_array<T>::value>{};
+   (::boost::has_trivial_move_assign<T>::value || ::boost::has_nothrow_assign<T>::value) &&  ! ::boost::is_array<T>::value>
+{
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_nothrow_move_assignable must be complete types");
+};
 
 #endif
 

--- a/include/boost/type_traits/is_nothrow_move_constructible.hpp
+++ b/include/boost/type_traits/is_nothrow_move_constructible.hpp
@@ -16,13 +16,18 @@
 #include <boost/type_traits/intrinsics.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/type_traits/is_complete.hpp>
+#include <boost/static_assert.hpp>
 
 #ifdef BOOST_IS_NOTHROW_MOVE_CONSTRUCT
 
 namespace boost {
 
 template <class T>
-struct is_nothrow_move_constructible : public integral_constant<bool, BOOST_IS_NOTHROW_MOVE_CONSTRUCT(T)>{};
+struct is_nothrow_move_constructible : public integral_constant<bool, BOOST_IS_NOTHROW_MOVE_CONSTRUCT(T)>
+{
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_nothrow_move_constructible must be complete types");
+};
 
 template <class T> struct is_nothrow_move_constructible<volatile T> : public ::boost::false_type {};
 template <class T> struct is_nothrow_move_constructible<const volatile T> : public ::boost::false_type{};
@@ -47,7 +52,10 @@ struct false_or_cpp11_noexcept_move_constructible <
 }
 
 template <class T> struct is_nothrow_move_constructible
-   : public integral_constant<bool, ::boost::detail::false_or_cpp11_noexcept_move_constructible<T>::value>{};
+   : public integral_constant<bool, ::boost::detail::false_or_cpp11_noexcept_move_constructible<T>::value>
+{
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_nothrow_move_constructible must be complete types");
+};
 
 template <class T> struct is_nothrow_move_constructible<volatile T> : public ::boost::false_type {};
 template <class T> struct is_nothrow_move_constructible<const volatile T> : public ::boost::false_type{};
@@ -66,7 +74,9 @@ template <class T>
 struct is_nothrow_move_constructible
    : public integral_constant<bool,
    (::boost::has_trivial_move_constructor<T>::value || ::boost::has_nothrow_copy<T>::value) && !::boost::is_array<T>::value>
-{};
+{
+   BOOST_STATIC_ASSERT_MSG(boost::is_complete<T>::value, "Arguments to is_nothrow_move_constructible must be complete types");
+};
 
 #endif
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -39,6 +39,10 @@ rule all-tests {
      {
          result += [ run $(source) ] ;
      }
+     for local source in [ glob compile_fail/*.cpp ]
+     {
+         result += [ compile-fail $(source) ] ;
+     }
      #
      # These traits have both intrinsic support, and a std conforming version, test a version with intrinsics disabled for better code coverage:
      #

--- a/test/compile_fail/common_type2_fail.cpp
+++ b/test/compile_fail/common_type2_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/common_type.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return sizeof(boost::common_type<int, incomplete_type>::type);
+}
+
+

--- a/test/compile_fail/common_type_fail.cpp
+++ b/test/compile_fail/common_type_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/common_type.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return sizeof(boost::common_type<incomplete_type, int>::type);
+}
+
+

--- a/test/compile_fail/has_nothrow_assign_fail.cpp
+++ b/test/compile_fail/has_nothrow_assign_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/has_nothrow_assign.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::has_nothrow_assign<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/has_nothrow_cons_fail.cpp
+++ b/test/compile_fail/has_nothrow_cons_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/has_nothrow_constructor.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::has_nothrow_constructor<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/has_nothrow_copy_fail.cpp
+++ b/test/compile_fail/has_nothrow_copy_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/has_nothrow_copy.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::has_nothrow_copy<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/has_nothrow_destruct_fail.cpp
+++ b/test/compile_fail/has_nothrow_destruct_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/has_nothrow_destructor.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::has_nothrow_destructor<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_assignable_fail.cpp
+++ b/test/compile_fail/is_assignable_fail.cpp
@@ -7,6 +7,10 @@
 #  include <boost/type_traits/is_assignable.hpp>
 #include "../test.hpp"
 
+#ifndef BOOST_TT_HAS_WORKING_IS_COMPLETE
+#error "Sorry can't test this."
+#endif
+
 int main()
 {
    return boost::is_assignable<incomplete_type>::value;

--- a/test/compile_fail/is_assignable_fail.cpp
+++ b/test/compile_fail/is_assignable_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_assignable.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_assignable<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_base_of_fail.cpp
+++ b/test/compile_fail/is_base_of_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_base_of.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_base_of<UDT, incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_constructible_fail.cpp
+++ b/test/compile_fail/is_constructible_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_constructible.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_constructible<incomplete_type, int>::value;
+}
+
+

--- a/test/compile_fail/is_convertible2_fail.cpp
+++ b/test/compile_fail/is_convertible2_fail.cpp
@@ -1,0 +1,19 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_convertible.hpp>
+#include "../test.hpp"
+
+#if defined(CI_SUPPRESS_KNOWN_ISSUES) && defined(BOOST_MSVC) && (BOOST_MSVC <= 1800)
+#error "Sorry check doesn't work"
+#endif
+
+int main()
+{
+   return boost::is_convertible<incomplete_type, UDT>::value;
+}
+
+

--- a/test/compile_fail/is_convertible2_fail.cpp
+++ b/test/compile_fail/is_convertible2_fail.cpp
@@ -7,8 +7,8 @@
 #  include <boost/type_traits/is_convertible.hpp>
 #include "../test.hpp"
 
-#if defined(CI_SUPPRESS_KNOWN_ISSUES) && defined(BOOST_MSVC) && (BOOST_MSVC <= 1800)
-#error "Sorry check doesn't work"
+#ifndef BOOST_TT_HAS_WORKING_IS_COMPLETE
+#error "Sorry can't test this."
 #endif
 
 int main()

--- a/test/compile_fail/is_convertible_fail.cpp
+++ b/test/compile_fail/is_convertible_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_convertible.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_convertible<UDT, incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_copy_assignable_fail.cpp
+++ b/test/compile_fail/is_copy_assignable_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_copy_assignable.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_copy_assignable<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_copy_constructible_fail.cpp
+++ b/test/compile_fail/is_copy_constructible_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_copy_constructible.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_copy_constructible<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_default_constructible_fail.cpp
+++ b/test/compile_fail/is_default_constructible_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_default_constructible.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_default_constructible<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_destructible_fail.cpp
+++ b/test/compile_fail/is_destructible_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_destructible.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_destructible<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_empty_fail.cpp
+++ b/test/compile_fail/is_empty_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_empty.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_empty<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_list_constructible_fail.cpp
+++ b/test/compile_fail/is_list_constructible_fail.cpp
@@ -7,6 +7,10 @@
 #  include <boost/type_traits/is_list_constructible.hpp>
 #include "../test.hpp"
 
+#ifndef BOOST_TT_HAS_WORKING_IS_COMPLETE
+#error "Sorry can't test this."
+#endif
+
 int main()
 {
    return boost::is_list_constructible<incomplete_type>::value;

--- a/test/compile_fail/is_list_constructible_fail.cpp
+++ b/test/compile_fail/is_list_constructible_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_list_constructible.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_list_constructible<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_nothrow_move_assignable_fail.cpp
+++ b/test/compile_fail/is_nothrow_move_assignable_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_nothrow_move_assignable.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_nothrow_move_assignable<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_nothrow_move_constructible_fail.cpp
+++ b/test/compile_fail/is_nothrow_move_constructible_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_nothrow_move_constructible.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_nothrow_move_constructible<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_polymorphic_fail.cpp
+++ b/test/compile_fail/is_polymorphic_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_polymorphic.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_polymorphic<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_stateless_fail.cpp
+++ b/test/compile_fail/is_stateless_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_stateless.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_stateless<incomplete_type>::value;
+}
+
+

--- a/test/compile_fail/is_virtual_base_of_fail.cpp
+++ b/test/compile_fail/is_virtual_base_of_fail.cpp
@@ -1,0 +1,15 @@
+
+//  (C) Copyright John Maddock 2017. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#  include <boost/type_traits/is_virtual_base_of.hpp>
+#include "../test.hpp"
+
+int main()
+{
+   return boost::is_virtual_base_of<UDT, incomplete_type>::value;
+}
+
+

--- a/test/is_complete_test.cpp
+++ b/test/is_complete_test.cpp
@@ -31,7 +31,7 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int[2]>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const[3]>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int volatile[2][3]>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const volatile[4][5][6]>::value, true);
-#ifndef BOOST_NO_SFINAE
+#ifdef BOOST_TT_HAS_WORKING_IS_COMPLETE
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int[]>::value, false);
 #endif
 
@@ -43,7 +43,7 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<cmf>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<mf8>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<union_UDT>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<test_abc1>::value, true);
-#ifndef BOOST_NO_SFINAE
+#ifdef BOOST_TT_HAS_WORKING_IS_COMPLETE
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<incomplete_type>::value, false);
 #endif
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<polymorphic_base>::value, true);

--- a/test/is_complete_test.cpp
+++ b/test/is_complete_test.cpp
@@ -1,0 +1,55 @@
+
+//  (C) Copyright John Maddock 2000. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifdef TEST_STD
+#  include <type_traits>
+#else
+#  include <boost/type_traits/is_complete.hpp>
+#endif
+#include "test.hpp"
+#include "check_integral_constant.hpp"
+
+TT_TEST_BEGIN(is_complete)
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int volatile>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const volatile>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const&>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int volatile&>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const volatile&>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int*>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const*>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int volatile*>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const volatile*>::value, true);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const[3]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int volatile[2][3]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int const volatile[4][5][6]>::value, true);
+#ifndef BOOST_NO_SFINAE
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<int[]>::value, false);
+#endif
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<enum_UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<f1>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<mf1>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<cmf>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<mf8>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<union_UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<test_abc1>::value, true);
+#ifndef BOOST_NO_SFINAE
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<incomplete_type>::value, false);
+#endif
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<polymorphic_base>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<virtual_inherit6>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<foo0_t>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_complete<foo4_t>::value, true);
+
+TT_TEST_END
+


### PR DESCRIPTION
…s complete types as arguments.

This prevents some traits from doing the wrong thing (ie compiling but giving the wrong answer when handed an incomplete type.
See https://svn.boost.org/trac10/ticket/12285.
A by-product of this is we add is_complete as a new trait.