### PR TITLE
Fix compile errors on gcc 4.4 C++0x mode

### DIFF
--- a/include/boost/type_traits/is_complete.hpp
+++ b/include/boost/type_traits/is_complete.hpp
@@ -13,6 +13,14 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/is_function.hpp>
 
+#if !defined(BOOST_NO_SFINAE_EXPR) && !BOOST_WORKAROUND(BOOST_MSVC, <= 1900)
+#elif !defined(BOOST_NO_SFINAE) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
+
+#include <boost/type_traits/declval.hpp>
+#include <boost/type_traits/detail/yes_no_type.hpp>
+
+#endif
+
 /*
  * CAUTION:
  * ~~~~~~~~
@@ -57,7 +65,7 @@ namespace boost {
       template <class T>
       struct is_complete_imp
       {
-         template <class U, class = decltype(sizeof(std::declval< U >())) >
+         template <class U, class = decltype(sizeof(::boost::declval< U >())) >
          static type_traits::yes_type check(U*);
 
          template <class U>
@@ -70,7 +78,7 @@ namespace boost {
 
 
    template <class T>
-   struct is_complete : std::integral_constant<bool, ::boost::is_function<typename boost::remove_reference<T>::type>::value || ::boost::detail::is_complete_imp<T>::value>
+   struct is_complete : ::boost::integral_constant<bool, ::boost::is_function<typename boost::remove_reference<T>::type>::value || ::boost::detail::is_complete_imp<T>::value>
    {};
    template <class T>
    struct is_complete<T&> : is_complete<T> {};


### PR DESCRIPTION
While building quickbook, I'm getting compile errors for gcc 4.4 in C++0x mode. This is my quick attempt at fixing them, although the test still fails. Easiest solution might be to not use the C++11 features on this compiler in this case.

You can see the compile error at https://travis-ci.org/boostorg/quickbook/jobs/338435551:

```
In file included from ../../../boost/type_traits/is_default_constructible.hpp:15,
                 from ../../../boost/type_traits/has_nothrow_constructor.hpp:22,
                 from ../../../boost/optional/optional.hpp:38,
                 from ../../../boost/optional.hpp:15,
                 from ../../../boost/spirit/home/classic/core/match.hpp:15,
                 from ../../../boost/spirit/home/classic/core/scanner/scanner.hpp:14,
                 from ../../../boost/spirit/home/classic/core/parser.hpp:14,
                 from ../../../boost/spirit/home/classic/core/primitives/primitives.hpp:15,
                 from ../../../boost/spirit/include/classic_primitives.hpp:11,
                 from /home/travis/boost/tools/quickbook/test/src/text_diff.cpp:15:
../../../boost/type_traits/is_complete.hpp:60: error: ‘declval’ is not a member of ‘std’
../../../boost/type_traits/is_complete.hpp:60: error: expected primary-expression before ‘>’ token
../../../boost/type_traits/is_complete.hpp:60: error: expected primary-expression before ‘)’ token
../../../boost/type_traits/is_complete.hpp:61: error: expected initializer before ‘check’
../../../boost/type_traits/is_complete.hpp:64: error: expected initializer before ‘check’
../../../boost/type_traits/is_complete.hpp:66: error: ‘check’ was not declared in this scope
../../../boost/type_traits/is_complete.hpp:66: error: expected primary-expression before ‘>’ token
../../../boost/type_traits/is_complete.hpp:66: error: ‘yes_type’ is not a member of ‘boost::type_traits’
```