### PR TITLE
Include yes_no_type.hpp from is_complete.hpp

### DIFF
--- a/include/boost/type_traits/is_complete.hpp
+++ b/include/boost/type_traits/is_complete.hpp
@@ -12,6 +12,7 @@
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/is_function.hpp>
+#include <boost/type_traits/detail/yes_no_type.hpp>
 #include <boost/config/workaround.hpp>
 
 /*


### PR DESCRIPTION
Quickbook is failing to build for g++ 4.5 in C++0x mode, with this error:

```
In file included from ../boost/type_traits/is_default_constructible.hpp:15:0,
                 from ../boost/type_traits/has_nothrow_constructor.hpp:22,
                 from ../boost/optional/optional.hpp:38,
                 from ../boost/optional.hpp:15,
                 from ../boost/spirit/home/classic/core/match.hpp:15,
                 from ../boost/spirit/home/classic/core/scanner/scanner.hpp:14,
                 from ../boost/spirit/home/classic/core/parser.hpp:14,
                 from ../boost/spirit/home/classic/attribute/parametric.hpp:13,
                 from ../boost/spirit/home/classic/attribute.hpp:34,
                 from ../boost/spirit/include/classic_attribute.hpp:11,
                 from C:\boost\develop\boost_root\tools\quickbook\src\main_grammar.cpp:11:
../boost/type_traits/is_complete.hpp:62:17: error: 'yes_type' in namespace 'boost::type_traits' does not name a type
../boost/type_traits/is_complete.hpp:64:10: error: expected unqualified-id before 'template'
../boost/type_traits/is_complete.hpp:67:43: error: 'check' was not declared in this scope
../boost/type_traits/is_complete.hpp:67:50: error: expected primary-expression before '>' token
../boost/type_traits/is_complete.hpp:67:66: error: 'yes_type' is not a member of 'boost::type_traits'
```

From:

http://www.boost.org/development/tests/develop/developer/output/igaztanaga-develop-gcc-4-5c++03-boost-bin-v2-tools-quickbook-test-anchor-1_1-test-gcc-4-5c+-dbg-cxstd-0x-iso-dbg-symbl-off-lnk-sttc.html

The include isn't needed for all configurations, but the configuration logic is quite complex, so it didn't seem appropriate to repeat it.