### PR TITLE
Fix is_final for class templates on gcc

### DIFF
--- a/include/boost/type_traits/is_final.hpp
+++ b/include/boost/type_traits/is_final.hpp
@@ -13,14 +13,15 @@
 
 #include <boost/type_traits/intrinsics.hpp>
 #include <boost/type_traits/integral_constant.hpp>
-#ifdef BOOST_IS_FINAL
-#include <boost/type_traits/remove_cv.hpp>
-#endif
 
 namespace boost {
 
 #ifdef BOOST_IS_FINAL
-template <class T> struct is_final : public integral_constant<bool, BOOST_IS_FINAL(typename remove_cv<T>::type)> {};
+// Note: gcc 6.4 and 7.2 break for some template types if we use remove_cv here
+template <class T> struct is_final : public integral_constant<bool, BOOST_IS_FINAL(T)> {};
+template <class T> struct is_final< const T > : public integral_constant<bool, BOOST_IS_FINAL(T)> {};
+template <class T> struct is_final< volatile T > : public integral_constant<bool, BOOST_IS_FINAL(T)> {};
+template <class T> struct is_final< const volatile T > : public integral_constant<bool, BOOST_IS_FINAL(T)> {};
 #else
 template <class T> struct is_final : public integral_constant<bool, false> {};
 #endif

--- a/test/is_final_test.cpp
+++ b/test/is_final_test.cpp
@@ -38,9 +38,13 @@ TT_TEST_BEGIN(is_final)
 #  ifndef BOOST_IS_FINAL
    BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::is_final<final_UDT>::value, true, false);
    BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::is_final<final_UDT const>::value, true, false);
+   BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::is_final<final_UDT_template<int> >::value, true, false);
+   BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::is_final<final_UDT_template<int> const>::value, true, false);
 #  else
    BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_final<final_UDT>::value, true);
    BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_final<final_UDT const>::value, true);
+   BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_final<final_UDT_template<int> >::value, true);
+   BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_final<final_UDT_template<int> const>::value, true);
 #  endif
 #else
    std::cout <<

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -408,6 +408,9 @@ struct final_UDT final
 {};
 struct polymorphic_derived_final final : public polymorphic_derived2
 {};
+template< typename T >
+struct final_UDT_template final
+{};
 #endif
 
 


### PR DESCRIPTION
This fixes https://github.com/boostorg/type_traits/issues/66 and adds a test case.
