### PR TITLE
clang intrinsics: Use __is_trivially_constructible and __is_trivially…

### DIFF
--- a/include/boost/type_traits/intrinsics.hpp
+++ b/include/boost/type_traits/intrinsics.hpp
@@ -222,12 +222,14 @@
 #   if __has_feature(is_polymorphic)
 #     define BOOST_IS_POLYMORPHIC(T) __is_polymorphic(T)
 #   endif
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
 #   if __has_extension(is_trivially_constructible)
 #     define BOOST_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T) (__is_trivially_constructible(T, T&&) && is_constructible<T, T&&>::value && !::boost::is_volatile<T>::value)
 #   endif
 #   if __has_extension(is_trivially_assignable)
 #     define BOOST_HAS_TRIVIAL_MOVE_ASSIGN(T) (__is_trivially_assignable(T&, T&&) && is_assignable<T&, T&&>::value && !::boost::is_volatile<T>::value)
 #   endif
+#endif
 #   if (!defined(unix) && !defined(__unix__)) || defined(__LP64__) || !defined(__GNUC__)
 // GCC sometimes lies about alignment requirements
 // of type double on 32-bit unix platforms, use the

--- a/include/boost/type_traits/intrinsics.hpp
+++ b/include/boost/type_traits/intrinsics.hpp
@@ -222,11 +222,11 @@
 #   if __has_feature(is_polymorphic)
 #     define BOOST_IS_POLYMORPHIC(T) __is_polymorphic(T)
 #   endif
-#   if __has_feature(has_trivial_move_constructor)
-#     define BOOST_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T) (__has_trivial_move_constructor(T)  && is_constructible<T, T&&>::value && !::boost::is_volatile<T>::value)
+#   if __has_extension(is_trivially_constructible)
+#     define BOOST_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T) (__is_trivially_constructible(T, T&&) && is_constructible<T, T&&>::value && !::boost::is_volatile<T>::value)
 #   endif
-#   if __has_feature(has_trivial_move_assign)
-#     define BOOST_HAS_TRIVIAL_MOVE_ASSIGN(T) (__has_trivial_move_assign(T) && is_assignable<T&, T&&>::value && !::boost::is_volatile<T>::value)
+#   if __has_extension(is_trivially_assignable)
+#     define BOOST_HAS_TRIVIAL_MOVE_ASSIGN(T) (__is_trivially_assignable(T&, T&&) && is_assignable<T&, T&&>::value && !::boost::is_volatile<T>::value)
 #   endif
 #   if (!defined(unix) && !defined(__unix__)) || defined(__LP64__) || !defined(__GNUC__)
 // GCC sometimes lies about alignment requirements

--- a/include/boost/type_traits/intrinsics.hpp
+++ b/include/boost/type_traits/intrinsics.hpp
@@ -122,7 +122,10 @@
 //  This one fails if the default alignment has been changed with /Zp:
 //  #   define BOOST_ALIGNMENT_OF(T) __alignof(T)
 
-#   if defined(_MSC_VER) && (_MSC_VER >= 1700)
+#   if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#       define BOOST_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T) ((__is_trivially_constructible(T, T&&) || boost::is_pod<T>::value) && ! ::boost::is_volatile<T>::value && ! ::boost::is_reference<T>::value)
+#       define BOOST_HAS_TRIVIAL_MOVE_ASSIGN(T) ((__is_trivially_assignable(T, T&&) || boost::is_pod<T>::value) && ! ::boost::is_const<T>::value && !::boost::is_volatile<T>::value && ! ::boost::is_reference<T>::value)
+#   elif defined(_MSC_VER) && (_MSC_VER >= 1700)
 #       define BOOST_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T) ((__has_trivial_move_constructor(T) || boost::is_pod<T>::value) && ! ::boost::is_volatile<T>::value && ! ::boost::is_reference<T>::value)
 #       define BOOST_HAS_TRIVIAL_MOVE_ASSIGN(T) ((__has_trivial_move_assign(T) || boost::is_pod<T>::value) && ! ::boost::is_const<T>::value && !::boost::is_volatile<T>::value && ! ::boost::is_reference<T>::value)
 #   endif

--- a/test/has_trivial_move_assign_test.cpp
+++ b/test/has_trivial_move_assign_test.cpp
@@ -232,8 +232,10 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<empty_POD_union_UDT>
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_assign>::value, false);
 // Why does this fail on multiple compilers??
 //BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_destroy>::value, true);
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_construct>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_copy>::value, true);
+#endif
 /*
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_assign> >::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_destroy> >::value, true);

--- a/test/has_trivial_move_assign_test.cpp
+++ b/test/has_trivial_move_assign_test.cpp
@@ -220,6 +220,37 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<int[2][4][5][6][3]>:
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<UDT>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<empty_UDT>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<void>::value, false);
+
+#ifdef BOOST_HAS_TRIVIAL_MOVE_ASSIGN
+
+// cases we would like to succeed but can't implement in the language:
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<empty_POD_UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<POD_UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<POD_union_UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<empty_POD_union_UDT>::value, true);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_assign>::value, false);
+// Why does this fail on multiple compilers??
+//BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_destroy>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_construct>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_copy>::value, true);
+/*
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_assign> >::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_destroy> >::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_construct> >::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_copy> >::value, true);
+*/
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<test_abc1>::value, false);
+
+#ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1900)
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<non_copyable_movable>::value, true);
+#endif
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<copyable_non_moveable>::value, false);
+#endif
+
+#else
+
 // cases we would like to succeed but can't implement in the language:
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<empty_POD_UDT>::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<POD_UDT>::value, true, false);
@@ -230,18 +261,21 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_assig
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_destroy>::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_construct>::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<trivial_except_copy>::value, true, false);
+/*
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_assign> >::value, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_destroy> >::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_construct> >::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<wrap<trivial_except_copy> >::value, true, false);
-
+*/
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<test_abc1>::value, false);
 
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<non_copyable_movable>::value, true, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_assign<copyable_non_moveable>::value, false);
 #endif
-   
+
+#endif
+
 TT_TEST_END
 
 

--- a/test/has_trivial_move_constructor_test.cpp
+++ b/test/has_trivial_move_constructor_test.cpp
@@ -232,8 +232,10 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<empty_POD_union
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_copy>::value, false);
 // Why does this fail on multiple compilers??
 //BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_destroy>::value, true);
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_construct>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_assign>::value, true);
+#endif
 /*
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_copy> >::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_destroy> >::value, true);

--- a/test/has_trivial_move_constructor_test.cpp
+++ b/test/has_trivial_move_constructor_test.cpp
@@ -220,6 +220,37 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<int[3][2]>::val
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<int[2][4][5][6][3]>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<UDT>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<void>::value, false);
+
+#ifdef BOOST_HAS_TRIVIAL_MOVE_CONSTRUCTOR
+
+// cases we would like to succeed but can't implement in the language:
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<empty_POD_UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<POD_UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<POD_union_UDT>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<empty_POD_union_UDT>::value, true);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_copy>::value, false);
+// Why does this fail on multiple compilers??
+//BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_destroy>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_construct>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_assign>::value, true);
+/*
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_copy> >::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_destroy> >::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_construct> >::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_assign> >::value, true);
+*/
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<test_abc1>::value, false);
+
+#ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1900)
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<non_copyable_movable>::value, true);
+#endif
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<copyable_non_moveable>::value, false);
+#endif
+
+#else
+
 // cases we would like to succeed but can't implement in the language:
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<empty_POD_UDT>::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<POD_UDT>::value, true, false);
@@ -230,16 +261,19 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_destroy>::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_construct>::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<trivial_except_assign>::value, true, false);
+/*
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_copy> >::value, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_destroy> >::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_construct> >::value, true, false);
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<wrap<trivial_except_assign> >::value, true, false);
-
+*/
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<test_abc1>::value, false);
 
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 BOOST_CHECK_SOFT_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<non_copyable_movable>::value, true, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_trivial_move_constructor<copyable_non_moveable>::value, false);
+#endif
+
 #endif
 
 TT_TEST_END


### PR DESCRIPTION
…_assignable to test for trivial move construct and assign.

See https://github.com/boostorg/type_traits/issues/73.