### PR TITLE
Use boost::declval instead of std::declval

### DIFF
--- a/include/boost/type_traits/is_complete.hpp
+++ b/include/boost/type_traits/is_complete.hpp
@@ -9,6 +9,7 @@
 #ifndef BOOST_TT_IS_COMPLETE_HPP_INCLUDED
 #define BOOST_TT_IS_COMPLETE_HPP_INCLUDED
 
+#include <boost/type_traits/declval.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/is_function.hpp>
@@ -59,7 +60,7 @@ namespace boost {
       template <class T>
       struct is_complete_imp
       {
-         template <class U, class = decltype(sizeof(std::declval< U >())) >
+         template <class U, class = decltype(sizeof(boost::declval< U >())) >
          static type_traits::yes_type check(U*);
 
          template <class U>


### PR DESCRIPTION
This pull request replaces a `std::declval` found in `is_complete.hpp` with one from Boost.

std::declval is rather new, and thus it is not available on some compilers.