### PR TITLE
Fix for cl.exe with LLVM backend

### DIFF
--- a/include/boost/type_traits/has_trivial_move_assign.hpp
+++ b/include/boost/type_traits/has_trivial_move_assign.hpp
@@ -24,7 +24,7 @@
 #endif
 #endif
 
-#if defined(__GNUC__) || defined(__clang)
+#if defined(__GNUC__) || defined(__clang) || defined(__llvm__)
 #include <boost/type_traits/is_assignable.hpp>
 #include <boost/type_traits/is_volatile.hpp>
 #endif


### PR DESCRIPTION
When compiling with LLVM 6's cl.exe frontend (\LLVM\msbuild-bin\cl.exe) using LLVM's backend on Windows, the following compiler error is emitted:
boost\boost/type_traits/has_trivial_move_assign.hpp(49): error : no template named 'is_assignable'; did you mean 'std::is_assignable'?

The reason is that <boost/type_traits/is_assignable.hpp> is not included, because \_\_clang is not defined.

The proposed PR ensures that is_assignable.hpp is included in this situation.