### PR TITLE
is_assignable_test: Fixed copy-paste error

### DIFF
--- a/test/is_assignable_test.cpp
+++ b/test/is_assignable_test.cpp
@@ -27,7 +27,7 @@ struct non_assignable
 struct noexcept_assignable
 {
    noexcept_assignable();
-   noexcept_assignable& operator=(const non_assignable&)noexcept;
+   noexcept_assignable& operator=(const noexcept_assignable&)noexcept;
 };
 
 #endif


### PR DESCRIPTION
The test `is_assignable<noexcept_assignable&>` checks self-assignability, while the
operator was defined for other type, so it was testing the non-noexcept implicit
generated copy assignment operator instead.