### PR TITLE
Use make_void directly instead of void_t for compatibility

### DIFF
--- a/include/boost/type_traits/detail/has_binary_operator.hpp
+++ b/include/boost/type_traits/detail/has_binary_operator.hpp
@@ -47,25 +47,25 @@ namespace boost
 
       struct dont_care;
 
-      template <class T, class U, class Ret, class = boost::void_t<>>
+      template <class T, class U, class Ret, class = void>
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp) : public boost::false_type {};
 
       template <class T, class U, class Ret>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp)<T, U, Ret, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP std::declval<typename add_reference<U>::type>())> >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp)<T, U, Ret, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP std::declval<typename add_reference<U>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_convertible<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP std::declval<typename add_reference<U>::type>()), Ret>::value> {};
 
-      template <class T, class U, class = boost::void_t<> >
+      template <class T, class U, class = void >
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp) : public boost::false_type {};
 
       template <class T, class U>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp)<T, U, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP std::declval<typename add_reference<U>::type>())> >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp)<T, U, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP std::declval<typename add_reference<U>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_void<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP std::declval<typename add_reference<U>::type>())>::value> {};
 
-      template <class T, class U, class = boost::void_t<>>
+      template <class T, class U, class = void>
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp) : public boost::false_type {};
 
       template <class T, class U>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp)<T, U, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP std::declval<typename add_reference<U>::type>())> >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp)<T, U, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP std::declval<typename add_reference<U>::type>())>::type>
          : public boost::true_type {};
 
    }

--- a/include/boost/type_traits/detail/has_postfix_operator.hpp
+++ b/include/boost/type_traits/detail/has_postfix_operator.hpp
@@ -25,25 +25,25 @@ namespace boost
 
       struct dont_care;
 
-      template <class T, class Ret, class = boost::void_t<>>
+      template <class T, class Ret, class = void>
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp) : public boost::false_type {};
 
       template <class T, class Ret>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp)<T, Ret, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP) > >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp)<T, Ret, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP) >::type>
          : public boost::integral_constant<bool, ::boost::is_convertible<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP), Ret>::value> {};
 
-      template <class T, class = boost::void_t<> >
+      template <class T, class = void >
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp) : public boost::false_type {};
 
       template <class T>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp)<T, boost::void_t<decltype(std::declval<typename add_reference<T>::type>()BOOST_TT_TRAIT_OP)> >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp)<T, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>()BOOST_TT_TRAIT_OP)>::type>
          : public boost::integral_constant<bool, ::boost::is_void<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP)>::value> {};
 
-      template <class T, class = boost::void_t<>>
+      template <class T, class = void>
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp) : public boost::false_type {};
 
       template <class T>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp)<T, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP)> >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp)<T, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() BOOST_TT_TRAIT_OP)>::type>
          : public boost::true_type {};
 
    }

--- a/include/boost/type_traits/detail/has_prefix_operator.hpp
+++ b/include/boost/type_traits/detail/has_prefix_operator.hpp
@@ -34,25 +34,25 @@ namespace boost
 
       struct dont_care;
 
-      template <class T, class Ret, class = boost::void_t<>>
+      template <class T, class Ret, class = void>
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp) : public boost::false_type {};
 
       template <class T, class Ret>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp)<T, Ret, boost::void_t<decltype(BOOST_TT_TRAIT_OP std::declval<typename add_reference<T>::type>()) > >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _ret_imp)<T, Ret, typename boost::make_void<decltype(BOOST_TT_TRAIT_OP std::declval<typename add_reference<T>::type>()) >::type>
          : public boost::integral_constant<bool, ::boost::is_convertible<decltype(BOOST_TT_TRAIT_OP std::declval<typename add_reference<T>::type>() ), Ret>::value> {};
 
-      template <class T, class = boost::void_t<> >
+      template <class T, class = void >
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp) : public boost::false_type {};
 
       template <class T>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp)<T, boost::void_t<decltype(BOOST_TT_TRAIT_OP std::declval<typename add_reference<T>::type>())> >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _void_imp)<T, typename boost::make_void<decltype(BOOST_TT_TRAIT_OP std::declval<typename add_reference<T>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_void<decltype(BOOST_TT_TRAIT_OP std::declval<typename add_reference<T>::type>())>::value> {};
 
-      template <class T, class = boost::void_t<>>
+      template <class T, class = void>
       struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp) : public boost::false_type {};
 
       template <class T>
-      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp)<T, boost::void_t<decltype(BOOST_TT_TRAIT_OP std::declval<typename add_reference<T>::type>() )> >
+      struct BOOST_JOIN(BOOST_TT_TRAIT_NAME, _dc_imp)<T, typename boost::make_void<decltype(BOOST_TT_TRAIT_OP std::declval<typename add_reference<T>::type>() )>::type>
          : public boost::true_type {};
 
    }

--- a/include/boost/type_traits/has_minus.hpp
+++ b/include/boost/type_traits/has_minus.hpp
@@ -52,25 +52,25 @@ namespace boost
 
       struct dont_care;
 
-      template <class T, class U, class Ret, class = boost::void_t<>>
+      template <class T, class U, class Ret, class = void>
       struct has_minus_ret_imp : public boost::false_type {};
 
       template <class T, class U, class Ret>
-      struct has_minus_ret_imp<T, U, Ret, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() - std::declval<typename add_reference<U>::type>())> >
+      struct has_minus_ret_imp<T, U, Ret, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() - std::declval<typename add_reference<U>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_convertible<decltype(std::declval<typename add_reference<T>::type>() - std::declval<typename add_reference<U>::type>()), Ret>::value> {};
 
-      template <class T, class U, class = boost::void_t<> >
+      template <class T, class U, class = void >
       struct has_minus_void_imp : public boost::false_type {};
 
       template <class T, class U>
-      struct has_minus_void_imp<T, U, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() - std::declval<typename add_reference<U>::type>())> >
+      struct has_minus_void_imp<T, U, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() - std::declval<typename add_reference<U>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_void<decltype(std::declval<typename add_reference<T>::type>() - std::declval<typename add_reference<U>::type>())>::value> {};
 
-      template <class T, class U, class = boost::void_t<>>
+      template <class T, class U, class = void>
       struct has_minus_dc_imp : public boost::false_type {};
 
       template <class T, class U>
-      struct has_minus_dc_imp<T, U, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() - std::declval<typename add_reference<U>::type>())> >
+      struct has_minus_dc_imp<T, U, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() - std::declval<typename add_reference<U>::type>())>::type>
          : public boost::true_type {};
 
       template <class T, class U, class Ret>

--- a/include/boost/type_traits/has_minus_assign.hpp
+++ b/include/boost/type_traits/has_minus_assign.hpp
@@ -53,25 +53,25 @@ namespace boost
 
       struct dont_care;
 
-      template <class T, class U, class Ret, class = boost::void_t<>>
+      template <class T, class U, class Ret, class = void>
       struct has_minus_assign_ret_imp : public boost::false_type {};
 
       template <class T, class U, class Ret>
-      struct has_minus_assign_ret_imp<T, U, Ret, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() -= std::declval<typename add_reference<U>::type>())> >
+      struct has_minus_assign_ret_imp<T, U, Ret, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() -= std::declval<typename add_reference<U>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_convertible<decltype(std::declval<typename add_reference<T>::type>() -= std::declval<typename add_reference<U>::type>()), Ret>::value> {};
 
-      template <class T, class U, class = boost::void_t<> >
+      template <class T, class U, class = void >
       struct has_minus_assign_void_imp : public boost::false_type {};
 
       template <class T, class U>
-      struct has_minus_assign_void_imp<T, U, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() -= std::declval<typename add_reference<U>::type>())> >
+      struct has_minus_assign_void_imp<T, U, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() -= std::declval<typename add_reference<U>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_void<decltype(std::declval<typename add_reference<T>::type>() -= std::declval<typename add_reference<U>::type>())>::value> {};
 
-      template <class T, class U, class = boost::void_t<>>
+      template <class T, class U, class = void>
       struct has_minus_assign_dc_imp : public boost::false_type {};
 
       template <class T, class U>
-      struct has_minus_assign_dc_imp<T, U, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() -= std::declval<typename add_reference<U>::type>())> >
+      struct has_minus_assign_dc_imp<T, U, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() -= std::declval<typename add_reference<U>::type>())>::type>
          : public boost::true_type {};
 
       template <class T, class U, class Ret>

--- a/include/boost/type_traits/has_plus_assign.hpp
+++ b/include/boost/type_traits/has_plus_assign.hpp
@@ -56,25 +56,25 @@ namespace boost
 
       struct dont_care;
 
-      template <class T, class U, class Ret, class = boost::void_t<>>
+      template <class T, class U, class Ret, class = void>
       struct has_plus_assign_ret_imp : public boost::false_type {};
 
       template <class T, class U, class Ret>
-      struct has_plus_assign_ret_imp<T, U, Ret, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() += std::declval<typename add_reference<U>::type>())> >
+      struct has_plus_assign_ret_imp<T, U, Ret, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() += std::declval<typename add_reference<U>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_convertible<decltype(std::declval<typename add_reference<T>::type>() += std::declval<typename add_reference<U>::type>()), Ret>::value> {};
 
-      template <class T, class U, class = boost::void_t<> >
+      template <class T, class U, class = void >
       struct has_plus_assign_void_imp : public boost::false_type {};
 
       template <class T, class U>
-      struct has_plus_assign_void_imp<T, U, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() += std::declval<typename add_reference<U>::type>())> >
+      struct has_plus_assign_void_imp<T, U, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() += std::declval<typename add_reference<U>::type>())>::type>
          : public boost::integral_constant<bool, ::boost::is_void<decltype(std::declval<typename add_reference<T>::type>() += std::declval<typename add_reference<U>::type>())>::value> {};
 
-      template <class T, class U, class = boost::void_t<>>
+      template <class T, class U, class = void>
       struct has_plus_assign_dc_imp : public boost::false_type {};
 
       template <class T, class U>
-      struct has_plus_assign_dc_imp<T, U, boost::void_t<decltype(std::declval<typename add_reference<T>::type>() += std::declval<typename add_reference<U>::type>())> >
+      struct has_plus_assign_dc_imp<T, U, typename boost::make_void<decltype(std::declval<typename add_reference<T>::type>() += std::declval<typename add_reference<U>::type>())>::type>
          : public boost::true_type {};
 
       template <class T, class U, class Ret>

--- a/include/boost/type_traits/is_virtual_base_of.hpp
+++ b/include/boost/type_traits/is_virtual_base_of.hpp
@@ -44,7 +44,7 @@ namespace boost {
       // They can also fall back to the behaviour of reinterpret_cast, which allows is_virtual_base_of to work on non-class types too.
       // Note that because we are casting pointers there can be no user-defined operators to interfere.
       template<class T, class U,
-         boost::void_t<decltype((U*)(std::declval<T*>()))>* =
+         typename boost::make_void<decltype((U*)(std::declval<T*>()))>::type* =
          nullptr>
          constexpr bool is_virtual_base_impl(int) { return false; }
 


### PR DESCRIPTION
For users who have BOOST_NO_CXX11_TEMPLATE_ALIASES present while these are being compiled, as in Github issue #113 .