### PR TITLE
Fix the compiling errors in VS2019 ARM64 with /std:c++17

### DIFF
--- a/include/boost/type_traits/detail/is_function_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_function_cxx_11.hpp
@@ -376,7 +376,7 @@ namespace boost {
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
 #ifdef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
@@ -559,7 +559,7 @@ namespace boost {
    struct is_function<Ret __vectorcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 
-#endif // _MSC_VER
+#endif // defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
 
 #endif
 

--- a/include/boost/type_traits/detail/is_member_function_pointer_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_member_function_pointer_cxx_11.hpp
@@ -419,7 +419,7 @@ namespace boost {
    template <class Ret, class C, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(C::*)(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
 #ifdef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};


### PR DESCRIPTION
Skip __stdcall and __fastcall overloads on ARM and ARM64

Fix issue #121 