### PR TITLE
#123: Fixes for calling convention collision errors when compiling with /clr

### DIFF
--- a/include/boost/type_traits/detail/is_function_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_function_cxx_11.hpp
@@ -97,210 +97,198 @@ namespace boost {
    struct is_function<Ret(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // reference qualified:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // rvalue reference qualified:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)&&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)&&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)&&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #endif
 
 #endif // _MSC_VER
@@ -377,210 +365,198 @@ namespace boost {
    struct is_function<Ret(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // reference qualified:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // rvalue reference qualified:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __stdcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __vectorcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #endif
 
 #endif // defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)

--- a/include/boost/type_traits/detail/is_function_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_function_cxx_11.hpp
@@ -32,78 +32,108 @@ namespace boost {
 #define BOOST_TT_DEF_CALL
 #endif
    
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const qualified:
+   
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // volatile:
+   
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const volatile
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
    // Reference qualified:
 
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)& BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)& BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const qualified:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // volatile:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)volatile & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)volatile & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const volatile
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const volatile & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const volatile & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
    // rvalue reference qualified:
 
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)&& BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)&& BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const qualified:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // volatile:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const volatile
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
+
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
+
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
-#ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#ifndef _M_X64
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -113,13 +143,16 @@ namespace boost {
 #endif
 #endif
    // const:
+   
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -129,13 +162,15 @@ namespace boost {
 #endif
 #endif
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -145,13 +180,15 @@ namespace boost {
 #endif
 #endif
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -162,13 +199,15 @@ namespace boost {
 #endif
 
    // reference qualified:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -178,13 +217,15 @@ namespace boost {
 #endif
 #endif
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -194,13 +235,15 @@ namespace boost {
 #endif
 #endif
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -210,13 +253,15 @@ namespace boost {
 #endif
 #endif
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -227,13 +272,15 @@ namespace boost {
 #endif
 
    // rvalue reference qualified:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)&&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)&&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -243,13 +290,15 @@ namespace boost {
 #endif
 #endif
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -259,13 +308,15 @@ namespace boost {
 #endif
 #endif
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -275,13 +326,15 @@ namespace boost {
 #endif
 #endif
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -300,78 +353,106 @@ namespace boost {
 #undef BOOST_TT_NOEXCEPT_DECL
 #define BOOST_TT_NOEXCEPT_DECL noexcept
 
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const qualified:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // volatile:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const volatile
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
    // Reference qualified:
 
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)& BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)& BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const qualified:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // volatile:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)volatile & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)volatile & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const volatile
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const volatile & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const volatile & BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
    // rvalue reference qualified:
 
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const qualified:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // volatile:
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    // const volatile
+#if !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret BOOST_TT_DEF_CALL(Args...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
    template <class Ret, class ...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
+
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
+
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -381,13 +462,15 @@ namespace boost {
 #endif
 #endif
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -397,13 +480,15 @@ namespace boost {
 #endif
 #endif
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -413,13 +498,15 @@ namespace boost {
 #endif
 #endif
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -430,13 +517,15 @@ namespace boost {
 #endif
 
    // reference qualified:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -446,13 +535,15 @@ namespace boost {
 #endif
 #endif
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -462,13 +553,15 @@ namespace boost {
 #endif
 #endif
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -478,13 +571,15 @@ namespace boost {
 #endif
 #endif
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -495,13 +590,15 @@ namespace boost {
 #endif
 
    // rvalue reference qualified:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -511,13 +608,15 @@ namespace boost {
 #endif
 #endif
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -527,13 +626,15 @@ namespace boost {
 #endif
 #endif
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
@@ -543,13 +644,15 @@ namespace boost {
 #endif
 #endif
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_function<Ret __stdcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __clrcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
-   template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_function<Ret __stdcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
    template <class Ret, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_function<Ret __fastcall(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif

--- a/include/boost/type_traits/detail/is_function_ptr_tester.hpp
+++ b/include/boost/type_traits/detail/is_function_ptr_tester.hpp
@@ -52,7 +52,7 @@ yes_type is_function_ptr_tester(R(*)(...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R >
 yes_type is_function_ptr_tester(R(__stdcall*)());
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R >
 yes_type is_function_ptr_tester(R(__vectorcall*)());
 #endif
@@ -72,7 +72,7 @@ yes_type is_function_ptr_tester(R(*)(T0 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0));
 #endif
@@ -92,7 +92,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1));
 #endif
@@ -112,7 +112,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2));
 #endif
@@ -132,7 +132,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3));
 #endif
@@ -152,7 +152,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4));
 #endif
@@ -172,7 +172,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5));
 #endif
@@ -192,7 +192,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6));
 #endif
@@ -212,7 +212,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7));
 #endif
@@ -232,7 +232,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8 ...));
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8));
 #endif
@@ -252,7 +252,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9 ...)
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9));
 #endif
@@ -272,7 +272,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10));
 #endif
@@ -292,7 +292,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11));
 #endif
@@ -312,7 +312,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12));
 #endif
@@ -332,7 +332,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13));
 #endif
@@ -352,7 +352,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14));
 #endif
@@ -372,7 +372,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15));
 #endif
@@ -392,7 +392,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16));
 #endif
@@ -412,7 +412,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17));
 #endif
@@ -432,7 +432,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18));
 #endif
@@ -452,7 +452,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19));
 #endif
@@ -472,7 +472,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20));
 #endif
@@ -492,7 +492,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21));
 #endif
@@ -512,7 +512,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22));
 #endif
@@ -532,7 +532,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23));
 #endif
@@ -552,7 +552,7 @@ yes_type is_function_ptr_tester(R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23, class T24 >
 yes_type is_function_ptr_tester(R(__stdcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24));
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23, class T24 >
 yes_type is_function_ptr_tester(R(__vectorcall*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24));
 #endif
@@ -593,7 +593,7 @@ yes_type is_function_ptr_tester(R (*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,T) .
 @#ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 template <class R BOOST_PP_COMMA_IF(BOOST_PP_COUNTER) BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,class T) >
 yes_type is_function_ptr_tester(R (__stdcall*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,T)));
-@#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+@#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R BOOST_PP_COMMA_IF(BOOST_PP_COUNTER) BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER, class T) >
 yes_type is_function_ptr_tester(R(__vectorcall*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER, T)));
 @#endif

--- a/include/boost/type_traits/detail/is_likely_lambda.hpp
+++ b/include/boost/type_traits/detail/is_likely_lambda.hpp
@@ -28,7 +28,7 @@ struct is_likely_stateless_lambda : public false_type {};
 }}
 
 #elif !defined(BOOST_NO_CXX11_LAMBDAS) && !defined(BOOST_NO_CXX11_DECLTYPE) && !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES) && !BOOST_WORKAROUND(BOOST_MSVC, < 1900)\
-         && !(BOOST_WORKAROUND(BOOST_MSVC, == 1900) && defined(__CLR_VER))
+         && !(BOOST_WORKAROUND(BOOST_MSVC, == 1900) && defined(_MANAGED))
 
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/enable_if.hpp>

--- a/include/boost/type_traits/detail/is_mem_fun_pointer_tester.hpp
+++ b/include/boost/type_traits/detail/is_mem_fun_pointer_tester.hpp
@@ -69,7 +69,7 @@ template <class R, class T >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)() volatile);
 template <class R, class T >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)() const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)());
 template <class R, class T >
@@ -125,7 +125,7 @@ template <class R, class T, class T0 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0) volatile);
 template <class R, class T, class T0 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0));
 template <class R, class T, class T0 >
@@ -181,7 +181,7 @@ template <class R, class T, class T0, class T1 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1) volatile);
 template <class R, class T, class T0, class T1 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1));
 template <class R, class T, class T0, class T1 >
@@ -237,7 +237,7 @@ template <class R, class T, class T0, class T1, class T2 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2) volatile);
 template <class R, class T, class T0, class T1, class T2 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2));
 template <class R, class T, class T0, class T1, class T2 >
@@ -293,7 +293,7 @@ template <class R, class T, class T0, class T1, class T2, class T3 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3));
 template <class R, class T, class T0, class T1, class T2, class T3 >
@@ -349,7 +349,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4 >
@@ -405,7 +405,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5 >
@@ -461,7 +461,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6 >
@@ -517,7 +517,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7 >
@@ -573,7 +573,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8 >
@@ -629,7 +629,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9 >
@@ -685,7 +685,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10 >
@@ -741,7 +741,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11 >
@@ -797,7 +797,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12 >
@@ -853,7 +853,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13 >
@@ -909,7 +909,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14 >
@@ -965,7 +965,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
@@ -1021,7 +1021,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16 >
@@ -1077,7 +1077,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17 >
@@ -1133,7 +1133,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18 >
@@ -1189,7 +1189,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19 >
@@ -1245,7 +1245,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20 >
@@ -1301,7 +1301,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21 >
@@ -1357,7 +1357,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22 >
@@ -1413,7 +1413,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23 >
@@ -1469,7 +1469,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24) volatile);
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23, class T24 >
 yes_type is_mem_fun_pointer_tester(R(__stdcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24) const volatile);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23, class T24 >
 yes_type is_mem_fun_pointer_tester(R(__vectorcall T::*const volatile*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24));
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23, class T24 >
@@ -1557,7 +1557,7 @@ yes_type is_mem_fun_pointer_tester(R (__stdcall T::*const volatile*)(BOOST_PP_EN
 
 template <class R, class T BOOST_PP_COMMA_IF(BOOST_PP_COUNTER) BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,class T) >
 yes_type is_mem_fun_pointer_tester(R (__stdcall T::*const volatile*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,T)) const volatile);
-@#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+@#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 template <class R, class T BOOST_PP_COMMA_IF(BOOST_PP_COUNTER) BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,class T) >
 yes_type is_mem_fun_pointer_tester(R (__vectorcall T::*const volatile*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,T)));
 

--- a/include/boost/type_traits/detail/is_member_function_pointer_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_member_function_pointer_cxx_11.hpp
@@ -109,17 +109,19 @@ namespace boost {
    struct is_member_function_pointer<Ret(C::*)(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__clrcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -128,17 +130,19 @@ namespace boost {
 #endif
 
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -147,17 +151,19 @@ namespace boost {
 #endif
 
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -166,17 +172,19 @@ namespace boost {
 #endif
 
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -185,17 +193,19 @@ namespace boost {
 #endif
 
    // reference qualified:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -204,17 +214,19 @@ namespace boost {
 #endif
 
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -223,17 +235,19 @@ namespace boost {
 #endif
  
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -242,17 +256,19 @@ namespace boost {
 #endif
 
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -261,17 +277,19 @@ namespace boost {
 #endif
 
    // rvalue reference qualified:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -280,17 +298,19 @@ namespace boost {
 #endif
 
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -299,17 +319,19 @@ namespace boost {
 #endif
 
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -318,17 +340,19 @@ namespace boost {
 #endif
  
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -409,17 +433,19 @@ namespace boost {
    struct is_member_function_pointer<Ret(C::*)(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -428,17 +454,19 @@ namespace boost {
 #endif
 
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -447,17 +475,19 @@ namespace boost {
 #endif
 
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -466,17 +496,19 @@ namespace boost {
 #endif
 
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -485,17 +517,19 @@ namespace boost {
 #endif
 
    // reference qualified:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -504,17 +538,19 @@ namespace boost {
 #endif
 
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -523,17 +559,19 @@ namespace boost {
 #endif
 
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -542,17 +580,19 @@ namespace boost {
 #endif
 
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -561,17 +601,19 @@ namespace boost {
 #endif
 
    // rvalue reference qualified:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -580,17 +622,19 @@ namespace boost {
 #endif
 
    // const:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -599,17 +643,19 @@ namespace boost {
 #endif
 
    // volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
@@ -618,17 +664,19 @@ namespace boost {
 #endif
 
    // const volatile:
+#if !defined(_M_X64) && !defined(_M_CEE_SAFE) && !defined(_M_CEE_PURE)
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
+   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
+#endif
 #ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-   template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
-   struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>

--- a/include/boost/type_traits/detail/is_member_function_pointer_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_member_function_pointer_cxx_11.hpp
@@ -109,244 +109,233 @@ namespace boost {
    struct is_member_function_pointer<Ret(C::*)(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__clrcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // reference qualified:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
  
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // rvalue reference qualified:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
  
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__stdcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__fastcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret (__vectorcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
+
 #endif
 
 
@@ -420,246 +409,234 @@ namespace boost {
    struct is_member_function_pointer<Ret(C::*)(Args..., ...)const volatile && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)const BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)const volatile BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // reference qualified:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)const &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)const volatile &BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // rvalue reference qualified:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...) && BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)const &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
+#endif
 
    // const volatile:
-#ifdef __CLR_VER
+#ifdef _MANAGED
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__clrcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-
-#endif
+#else
 #ifndef _M_AMD64
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__stdcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#ifndef __CLR_VER
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__fastcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
-#endif
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__cdecl C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
-#if !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64)
    template <class Ret, class C, class...Args BOOST_TT_NOEXCEPT_PARAM>
    struct is_member_function_pointer<Ret(__vectorcall C::*)(Args...)const volatile &&BOOST_TT_NOEXCEPT_DECL> : public true_type {};
 #endif
 #endif
+
+#endif // defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64)
 
 
 #endif

--- a/test/has_nothrow_copy_test.cpp
+++ b/test/has_nothrow_copy_test.cpp
@@ -240,7 +240,7 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_nothrow_copy<test_abc1>::value, false);
 #ifndef BOOST_NO_CXX11_DELETED_FUNCTIONS
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_nothrow_copy<delete_copy>::value, false);
 #if !(defined(CI_SUPPRESS_KNOWN_ISSUES) && BOOST_WORKAROUND(BOOST_GCC, < 40600)) && !(defined(CI_SUPPRESS_KNOWN_ISSUES) && BOOST_WORKAROUND(BOOST_MSVC, == 1800))\
-  && !(defined(CI_SUPPRESS_KNOWN_ISSUES) && defined(__CLR_VER))
+  && !(defined(CI_SUPPRESS_KNOWN_ISSUES) && defined(_MANAGED))
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::has_nothrow_copy<delete_move>::value, false);
 #endif
 #endif

--- a/test/is_function_test.cpp
+++ b/test/is_function_test.cpp
@@ -94,14 +94,14 @@ typedef void __cdecl cfoo2_t(int&, double);
 typedef void __cdecl cfoo3_t(int&, bool, int, int);
 typedef void __cdecl cfoo4_t(int, bool, int*, int[], int, int, int, int, int);
 
-#ifndef __CLR_VER
+#ifndef _MANAGED
 typedef void __fastcall ffoo0_t();
 typedef void __fastcall ffoo1_t(int);
 typedef void __fastcall ffoo2_t(int&, double);
 typedef void __fastcall ffoo3_t(int&, bool, int, int);
 typedef void __fastcall ffoo4_t(int, bool, int*, int[], int, int, int, int, int);
 #endif
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 typedef void __vectorcall vfoo0_t();
 typedef void __vectorcall vfoo1_t(int);
 typedef void __vectorcall vfoo2_t(int&, double);
@@ -120,7 +120,7 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<cfoo2_t>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<cfoo3_t>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<cfoo4_t>::value, true);
 
-#ifndef __CLR_VER
+#ifndef _MANAGED
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<ffoo0_t>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<ffoo1_t>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<ffoo2_t>::value, true);
@@ -128,7 +128,7 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<ffoo3_t>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<ffoo4_t>::value, true);
 #endif
 
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<vfoo0_t>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<vfoo1_t>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_function<vfoo2_t>::value, true);

--- a/test/is_member_func_test.cpp
+++ b/test/is_member_func_test.cpp
@@ -70,13 +70,13 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_member_function_pointer<void>::value, fal
 
 typedef void (__stdcall test_abc1::*scall_proc)();
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_member_function_pointer<scall_proc>::value, true);
-#ifndef __CLR_VER
+#ifndef _MANAGED
 typedef void (__fastcall test_abc1::*fcall_proc)(int);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_member_function_pointer<fcall_proc>::value, true);
 #endif
 typedef void (__cdecl test_abc1::*ccall_proc)(int, long, double);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_member_function_pointer<ccall_proc>::value, true);
-#if (_MSC_VER >= 1800) && !defined(__CLR_VER) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
+#if (_MSC_VER >= 1800) && !defined(_MANAGED) && (defined(_M_IX86_FP) && (_M_IX86_FP >= 2) || defined(_M_X64))
 typedef void(__vectorcall test_abc1::*vcall_proc)(int, long, double, double, double, double);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_member_function_pointer<vcall_proc>::value, true);
 #endif

--- a/test/is_member_pointer_test.cpp
+++ b/test/is_member_pointer_test.cpp
@@ -31,7 +31,7 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_member_pointer<foo0_t>::value, false);
 #ifdef BOOST_TT_TEST_MS_FUNC_SIGS
 typedef void (__stdcall test_abc1::*scall_proc)();
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_member_pointer<scall_proc>::value, true);
-#ifndef __CLR_VER
+#ifndef _MANAGED
 typedef void (__fastcall test_abc1::*fcall_proc)(int);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_member_pointer<fcall_proc>::value, true);
 #endif

--- a/test/type_with_alignment_test.cpp
+++ b/test/type_with_alignment_test.cpp
@@ -25,7 +25,7 @@ struct __declspec(align(64)) a64 { char m[64]; };
 struct __declspec(align(128)) a128 { char m[128]; };
 #endif
 
-#ifdef __CLR_VER
+#ifdef _MANAGED
 #pragma warning(disable:4793)  // vaarg function
 #endif
 


### PR DESCRIPTION
- Changed `__CLR_VER` to `_MANAGED` in accordance with [Microsoft's guidance on `/clr` detection](https://docs.microsoft.com/en-us/cpp/dotnet/how-to-detect-clr-compilation?view=vs-2019)
- Modified preprocessor conditional checks to more explicitly control the effect on `/clr` compilation on enabled calling conventions (`__clrcall` will be the enabled if and only if `_MANAGED` is set; standard logic will be used in all other cases)

I've tested these changes using MSVC to build both 32- and 64-bit projects with and without the `/clr` flag enabled.