### PR TITLE
Fix -Wconversion warning for GCC / 64 bits

### DIFF
--- a/include/boost/type_traits/is_complete.hpp
+++ b/include/boost/type_traits/is_complete.hpp
@@ -15,6 +15,7 @@
 #include <boost/type_traits/is_function.hpp>
 #include <boost/type_traits/detail/yes_no_type.hpp>
 #include <boost/config/workaround.hpp>
+#include <cstddef>
 
 /*
  * CAUTION:
@@ -40,7 +41,7 @@ namespace boost {
 
    namespace detail{
 
-      template <unsigned N>
+      template <std::size_t N>
       struct ok_tag { double d; char c[N]; };
 
       template <class T>


### PR DESCRIPTION
../../boost/type_traits/is_complete.hpp:47:14: error: conversion from ‘long unsigned int’ to ‘unsigned int’ may change value 
       ok_tag<sizeof(T)> check_is_complete(int);