### PR TITLE
Make build `-Wundef` clean

### DIFF
--- a/include/boost/type_traits/detail/is_function_ptr_helper.hpp
+++ b/include/boost/type_traits/detail/is_function_ptr_helper.hpp
@@ -49,7 +49,7 @@ struct is_function_ptr_helper<R(*)()> { BOOST_STATIC_CONSTANT(bool, value = true
 template <class R >
 struct is_function_ptr_helper<R(*)(...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R >
 struct is_function_ptr_helper<R(*)()noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -63,7 +63,7 @@ struct is_function_ptr_helper<R(*)(T0)> { BOOST_STATIC_CONSTANT(bool, value = tr
 template <class R, class T0>
 struct is_function_ptr_helper<R(*)(T0 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0>
 struct is_function_ptr_helper<R(*)(T0)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -77,7 +77,7 @@ struct is_function_ptr_helper<R(*)(T0, T1)> { BOOST_STATIC_CONSTANT(bool, value 
 template <class R, class T0, class T1>
 struct is_function_ptr_helper<R(*)(T0, T1 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1>
 struct is_function_ptr_helper<R(*)(T0, T1)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -91,7 +91,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2)> { BOOST_STATIC_CONSTANT(bool, va
 template <class R, class T0, class T1, class T2>
 struct is_function_ptr_helper<R(*)(T0, T1, T2 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2>
 struct is_function_ptr_helper<R(*)(T0, T1, T2)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -105,7 +105,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3)> { BOOST_STATIC_CONSTANT(bool
 template <class R, class T0, class T1, class T2, class T3>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -119,7 +119,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4)> { BOOST_STATIC_CONSTANT(
 template <class R, class T0, class T1, class T2, class T3, class T4>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -133,7 +133,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5)> { BOOST_STATIC_CONST
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -147,7 +147,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6)> { BOOST_STATIC_C
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -161,7 +161,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7)> { BOOST_STAT
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -175,7 +175,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8)> { BOOST_
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -189,7 +189,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)> { BO
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -203,7 +203,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -217,7 +217,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -231,7 +231,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -245,7 +245,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -259,7 +259,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -273,7 +273,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -287,7 +287,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -301,7 +301,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -315,7 +315,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -329,7 +329,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -343,7 +343,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -357,7 +357,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -371,7 +371,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -385,7 +385,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -399,7 +399,7 @@ struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23, class T24>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24 ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23, class T24>
 struct is_function_ptr_helper<R(*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -432,7 +432,7 @@ struct is_function_ptr_helper<R (*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,T))> {
 template <class R BOOST_PP_COMMA_IF(BOOST_PP_COUNTER) BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,class T)>
 struct is_function_ptr_helper<R (*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,T) ...)> { BOOST_STATIC_CONSTANT(bool, value = true); };
 @#endif
-@#if __cpp_noexcept_function_type
+@#ifdef __cpp_noexcept_function_type
 template <class R BOOST_PP_COMMA_IF(BOOST_PP_COUNTER) BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER, class T)>
 struct is_function_ptr_helper<R(*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER, T))noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 @#ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING

--- a/include/boost/type_traits/detail/is_mem_fun_pointer_impl.hpp
+++ b/include/boost/type_traits/detail/is_mem_fun_pointer_impl.hpp
@@ -67,7 +67,7 @@ template <class R, class T >
 struct is_mem_fun_pointer_impl<R(T::*)(...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T >
 struct is_mem_fun_pointer_impl<R(T::*)()noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -113,7 +113,7 @@ template <class R, class T, class T0>
 struct is_mem_fun_pointer_impl<R(T::*)(T0 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0>
 struct is_mem_fun_pointer_impl<R(T::*)(T0)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -159,7 +159,7 @@ template <class R, class T, class T0, class T1>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -205,7 +205,7 @@ template <class R, class T, class T0, class T1, class T2>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -251,7 +251,7 @@ template <class R, class T, class T0, class T1, class T2, class T3>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -297,7 +297,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -343,7 +343,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -389,7 +389,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -435,7 +435,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -481,7 +481,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -527,7 +527,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -573,7 +573,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -619,7 +619,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -665,7 +665,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -711,7 +711,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -757,7 +757,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -803,7 +803,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -849,7 +849,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -895,7 +895,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -941,7 +941,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -987,7 +987,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -1033,7 +1033,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -1079,7 +1079,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -1125,7 +1125,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -1171,7 +1171,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -1217,7 +1217,7 @@ template <class R, class T, class T0, class T1, class T2, class T3, class T4, cl
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24 ...) const volatile> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #endif
 #endif
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 template <class R, class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16, class T17, class T18, class T19, class T20, class T21, class T22, class T23, class T24>
 struct is_mem_fun_pointer_impl<R(T::*)(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };
 #ifndef BOOST_TT_NO_ELLIPSIS_IN_FUNC_TESTING
@@ -1290,7 +1290,7 @@ struct is_mem_fun_pointer_impl<R (T::*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER,T)
 @#endif
 @#endif
 
-@#if __cpp_noexcept_function_type
+@#ifdef __cpp_noexcept_function_type
 
 template <class R, class T BOOST_PP_COMMA_IF(BOOST_PP_COUNTER) BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER, class T)>
 struct is_mem_fun_pointer_impl<R(T::*)(BOOST_PP_ENUM_PARAMS(BOOST_PP_COUNTER, T))noexcept> { BOOST_STATIC_CONSTANT(bool, value = true); };

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -25,6 +25,7 @@ project : requirements
    <toolset>gcc:<cxxflags>-Wno-uninitialized
    <toolset>gcc:<cxxflags>-Wno-int-in-bool-context
    <toolset>gcc:<cxxflags>-Wno-bool-operation
+   <toolset>gcc:<cxxflags>-Wundef
    <toolset>gcc:<warnings-as-errors>on
    <toolset>intel:<warnings-as-errors>on
    <toolset>sun:<warnings-as-errors>on

--- a/test/is_function_test.cpp
+++ b/test/is_function_test.cpp
@@ -43,7 +43,7 @@ typedef void foo1_t(int);
 typedef void foo2_t(int&, double);
 typedef void foo3_t(int&, bool, int, int);
 typedef void foo4_t(int, bool, int*, int[], int, int, int, int, int);
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 typedef int foo5_t(void)noexcept;
 typedef int foo6_t(double)noexcept(false);
 typedef int foo7_t(int, double)noexcept(true);

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -193,7 +193,7 @@ struct UDT
    int f2();
    int f3(int);
    int f4(int, float);
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
    void f5()noexcept;
    int f6(int)noexcept(true);
    double f7()noexcept(false);
@@ -209,7 +209,7 @@ typedef int (UDT::*mf3)(int);
 typedef int (UDT::*mf4)(int, float);
 typedef int (UDT::*mp);
 typedef int (UDT::*cmf)(int) const;
-#if __cpp_noexcept_function_type
+#ifdef __cpp_noexcept_function_type
 typedef void (UDT::*mf5)()noexcept;
 typedef int (UDT::*mf6)(int)noexcept;
 typedef double (UDT::*mf7)()noexcept;


### PR DESCRIPTION
Use `#ifdef __cpp_noexcept_function_type` instead of
`#if __cpp_noexcept_function_type` to avoid `-Wundef` warnings.
Also add that flag to the test flags to detect those on CI.