### PR TITLE
Replace clang 15 deprecated intrinsics

### DIFF
--- a/include/boost/type_traits/intrinsics.hpp
+++ b/include/boost/type_traits/intrinsics.hpp
@@ -160,7 +160,7 @@
 #   define BOOST_HAS_TYPE_TRAITS_INTRINSICS
 #endif
 
-#if defined(BOOST_CLANG) && defined(__has_feature) && (!(defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ < 11)) || defined(__CUDA__))
+#if defined(BOOST_CLANG) && defined(__has_feature) && defined(__has_builtin) && (!(defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ < 11)) || defined(__CUDA__))
 //
 // Note that these intrinsics are disabled for the CUDA meta-compiler as it appears
 // to not support them, even though the underlying clang compiler does so.
@@ -183,37 +183,37 @@
 #   if (!defined(__GLIBCXX__) || (__GLIBCXX__ >= 20080306 && __GLIBCXX__ != 20080519)) && __has_feature(is_empty)
 #     define BOOST_IS_EMPTY(T) __is_empty(T)
 #   endif
-#   if defined(__has_builtin) && __has_builtin(__is_trivially_constructible)
+#   if __has_builtin(__is_trivially_constructible)
 #     define BOOST_HAS_TRIVIAL_CONSTRUCTOR(T) __is_trivially_constructible(T)
 #   elif __has_feature(has_trivial_constructor)
 #     define BOOST_HAS_TRIVIAL_CONSTRUCTOR(T) __has_trivial_constructor(T)
 #   endif
-#   if defined(__has_builtin) && __has_builtin(__is_trivially_copyable)
+#   if __has_builtin(__is_trivially_copyable)
 #     define BOOST_HAS_TRIVIAL_COPY(T) (__is_trivially_copyable(T) && !is_reference<T>::value)
 #   elif __has_feature(has_trivial_copy)
 #     define BOOST_HAS_TRIVIAL_COPY(T) (__has_trivial_copy(T) && !is_reference<T>::value)
 #   endif
-#   if defined(__has_builtin) && __has_builtin(__is_trivially_assignable)
+#   if __has_builtin(__is_trivially_assignable)
 #     define BOOST_HAS_TRIVIAL_ASSIGN(T) (__is_trivially_assignable(T&, const T&) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
 #   elif __has_feature(has_trivial_assign)
 #     define BOOST_HAS_TRIVIAL_ASSIGN(T) (__has_trivial_assign(T) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
 #   endif
-#   if defined(__has_builtin) && __has_builtin(__is_trivially_destructible)
+#   if __has_builtin(__is_trivially_destructible)
 #     define BOOST_HAS_TRIVIAL_DESTRUCTOR(T) (__is_trivially_destructible(T)  && is_destructible<T>::value)
 #   elif __has_feature(has_trivial_destructor)
 #     define BOOST_HAS_TRIVIAL_DESTRUCTOR(T) (__has_trivial_destructor(T)  && is_destructible<T>::value)
 #   endif
-#   if defined(__has_builtin) && __has_builtin(__is_nothrow_constructible)
+#   if __has_builtin(__is_nothrow_constructible)
 #     define BOOST_HAS_NOTHROW_CONSTRUCTOR(T) (__is_nothrow_constructible(T) && is_default_constructible<T>::value)
 #   elif __has_feature(has_nothrow_constructor)
 #     define BOOST_HAS_NOTHROW_CONSTRUCTOR(T) (__has_nothrow_constructor(T) && is_default_constructible<T>::value)
 #   endif
-#   if defined(__has_builtin) && __has_builtin(__is_nothrow_constructible)
+#   if __has_builtin(__is_nothrow_constructible)
 #     define BOOST_HAS_NOTHROW_COPY(T) (__is_nothrow_constructible(T, const T&) && !is_volatile<T>::value && !is_reference<T>::value && is_copy_constructible<T>::value)
 #   elif __has_feature(has_nothrow_copy)
 #     define BOOST_HAS_NOTHROW_COPY(T) (__has_nothrow_copy(T) && !is_volatile<T>::value && !is_reference<T>::value && is_copy_constructible<T>::value)
 #   endif
-#   if defined(__has_builtin) && __has_builtin(__is_nothrow_assignable)
+#   if __has_builtin(__is_nothrow_assignable)
 #     define BOOST_HAS_NOTHROW_ASSIGN(T) (__is_nothrow_assignable(T&, const T&) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
 #   elif __has_feature(has_nothrow_assign)
 #     define BOOST_HAS_NOTHROW_ASSIGN(T) (__has_nothrow_assign(T) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)

--- a/include/boost/type_traits/intrinsics.hpp
+++ b/include/boost/type_traits/intrinsics.hpp
@@ -183,25 +183,39 @@
 #   if (!defined(__GLIBCXX__) || (__GLIBCXX__ >= 20080306 && __GLIBCXX__ != 20080519)) && __has_feature(is_empty)
 #     define BOOST_IS_EMPTY(T) __is_empty(T)
 #   endif
-#   if __has_feature(has_trivial_constructor)
+#   if defined(__has_builtin) && __has_builtin(__is_trivially_constructible)
+#     define BOOST_HAS_TRIVIAL_CONSTRUCTOR(T) __is_trivially_constructible(T)
+#   elif __has_feature(has_trivial_constructor)
 #     define BOOST_HAS_TRIVIAL_CONSTRUCTOR(T) __has_trivial_constructor(T)
 #   endif
-#   if __has_feature(has_trivial_copy)
+#   if defined(__has_builtin) && __has_builtin(__is_trivially_copyable)
+#     define BOOST_HAS_TRIVIAL_COPY(T) (__is_trivially_copyable(T) && !is_reference<T>::value)
+#   elif __has_feature(has_trivial_copy)
 #     define BOOST_HAS_TRIVIAL_COPY(T) (__has_trivial_copy(T) && !is_reference<T>::value)
 #   endif
-#   if __has_feature(has_trivial_assign)
+#   if defined(__has_builtin) && __has_builtin(__is_trivially_assignable)
+#     define BOOST_HAS_TRIVIAL_ASSIGN(T) (__is_trivially_assignable(T&, const T&) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
+#   elif __has_feature(has_trivial_assign)
 #     define BOOST_HAS_TRIVIAL_ASSIGN(T) (__has_trivial_assign(T) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
 #   endif
-#   if __has_feature(has_trivial_destructor)
+#   if defined(__has_builtin) && __has_builtin(__is_trivially_destructible)
+#     define BOOST_HAS_TRIVIAL_DESTRUCTOR(T) (__is_trivially_destructible(T)  && is_destructible<T>::value)
+#   elif __has_feature(has_trivial_destructor)
 #     define BOOST_HAS_TRIVIAL_DESTRUCTOR(T) (__has_trivial_destructor(T)  && is_destructible<T>::value)
 #   endif
-#   if __has_feature(has_nothrow_constructor)
+#   if defined(__has_builtin) && __has_builtin(__is_nothrow_constructible)
+#     define BOOST_HAS_NOTHROW_CONSTRUCTOR(T) (__is_nothrow_constructible(T) && is_default_constructible<T>::value)
+#   elif __has_feature(has_nothrow_constructor)
 #     define BOOST_HAS_NOTHROW_CONSTRUCTOR(T) (__has_nothrow_constructor(T) && is_default_constructible<T>::value)
 #   endif
-#   if __has_feature(has_nothrow_copy)
+#   if defined(__has_builtin) && __has_builtin(__is_nothrow_constructible)
+#     define BOOST_HAS_NOTHROW_COPY(T) (__is_nothrow_constructible(T, const T&) && !is_volatile<T>::value && !is_reference<T>::value && is_copy_constructible<T>::value)
+#   elif __has_feature(has_nothrow_copy)
 #     define BOOST_HAS_NOTHROW_COPY(T) (__has_nothrow_copy(T) && !is_volatile<T>::value && !is_reference<T>::value && is_copy_constructible<T>::value)
 #   endif
-#   if __has_feature(has_nothrow_assign)
+#   if defined(__has_builtin) && __has_builtin(__is_nothrow_assignable)
+#     define BOOST_HAS_NOTHROW_ASSIGN(T) (__is_nothrow_assignable(T&, const T&) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
+#   elif __has_feature(has_nothrow_assign)
 #     define BOOST_HAS_NOTHROW_ASSIGN(T) (__has_nothrow_assign(T) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
 #   endif
 #   if __has_feature(has_virtual_destructor)


### PR DESCRIPTION
Fixes https://github.com/boostorg/type_traits/issues/173

https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#non-comprehensive-list-of-changes-in-this-release

> Some type-trait builtins, such as `__has_trivial_assign`, have been documented as deprecated for a while because their semantics don’t mix well with post-C++11 type-traits. Clang now emits deprecation warnings for them under the flag `-Wdeprecated-builtins`.

Should be OK to replace with `__is_trivially_assignable` etc. (with some adjustments). Will post a patch.