### PR TITLE
Add `is swappable` trait.

### DIFF
--- a/doc/history.qbk
+++ b/doc/history.qbk
@@ -1,4 +1,4 @@
-[/ 
+[/
   Copyright 2009 John Maddock.
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE_1_0.txt or copy at
@@ -6,6 +6,10 @@
 ]
 
 [section:history History]
+
+[h4 Boost-1.82.0]
+
+* Added __is_swappable trait.
 
 [h4 Boost-1.70.0]
 

--- a/doc/history.qbk
+++ b/doc/history.qbk
@@ -10,6 +10,7 @@
 [h4 Boost-1.82.0]
 
 * Added __is_swappable trait.
+* Added a workaround for gcc 4.6 that allows __is_nothrow_swappable to work.
 
 [h4 Boost-1.70.0]
 

--- a/doc/is_swappable.qbk
+++ b/doc/is_swappable.qbk
@@ -1,0 +1,26 @@
+[/
+  Copyright 2023 Andrey Semashev
+
+  Distributed under the Boost Software License, Version 1.0.
+
+  (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt).
+]
+
+[section:is_swappable is_swappable]
+
+   template <class T>
+   struct is_swappable : public __tof {};
+
+__inherit If the expression `swap(declval<T&>(), declval<T&>())` (in a context
+where `std::swap` is visible) is valid, inherits from __true_type, otherwise from __false_type.
+
+__compat This trait requires C++11 for full support. On C++03 compilers it will inherit from __true_type
+for scalar types (including integral, floating point, enumeration, pointer and pointer-to-member types)
+and from __false_type for anything else. If MSVC standard library is used, C++17
+is required for full support. In this case, in C++11 and C++14 modes the trait will inherit from __true_type
+for types that support move construction and move assignment and from __false_type for other types.
+
+__header ` #include <boost/type_traits/is_swappable.hpp>` or ` #include <boost/type_traits.hpp>`
+
+[endsect]

--- a/doc/type_traits.qbk
+++ b/doc/type_traits.qbk
@@ -108,6 +108,7 @@
 [def __is_nothrow_move_constructible [link boost_typetraits.reference.is_nothrow_move_constructible is_nothrow_move_constructible]]
 [def __has_nothrow_assign [link boost_typetraits.reference.has_nothrow_assign has_nothrow_assign]]
 [def __is_nothrow_move_assignable [link boost_typetraits.reference.is_nothrow_move_assignable is_nothrow_move_assignable]]
+[def __is_swappable [link boost_typetraits.reference.is_swappable is_swappable]]
 [def __is_nothrow_swappable [link boost_typetraits.reference.is_nothrow_swappable is_nothrow_swappable]]
 
 [def __is_base_of [link boost_typetraits.reference.is_base_of is_base_of]]
@@ -440,6 +441,7 @@ See __has_trivial_constructor.
 [include is_scoped_enum.qbk]
 [include is_signed.qbk]
 [include is_stateless.qbk]
+[include is_swappable.qbk]
 [include is_trivially_copyable.qbk]
 [include is_unbounded_array.qbk]
 [include is_union.qbk]

--- a/include/boost/type_traits.hpp
+++ b/include/boost/type_traits.hpp
@@ -131,6 +131,7 @@
 #include <boost/type_traits/is_scoped_enum.hpp>
 #include <boost/type_traits/is_signed.hpp>
 #include <boost/type_traits/is_stateless.hpp>
+#include <boost/type_traits/is_swappable.hpp>
 #include <boost/type_traits/is_trivially_copyable.hpp>
 #include <boost/type_traits/is_union.hpp>
 #include <boost/type_traits/is_unscoped_enum.hpp>

--- a/include/boost/type_traits/detail/is_swappable_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_swappable_cxx_11.hpp
@@ -1,0 +1,37 @@
+#ifndef BOOST_TYPE_TRAITS_DETAIL_IS_SWAPPABLE_CXX_11_HPP_INCLUDED
+#define BOOST_TYPE_TRAITS_DETAIL_IS_SWAPPABLE_CXX_11_HPP_INCLUDED
+
+//  Copyright 2017 Peter Dimov
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/config.hpp>
+#include <boost/type_traits/declval.hpp>
+#include <boost/type_traits/integral_constant.hpp>
+#if __cplusplus >= 201103L || defined(BOOST_DINKUMWARE_STDLIB)
+#include <utility> // for std::swap (C++11)
+#else
+#include <algorithm> // for std::swap (C++98)
+#endif
+
+// Intentionally not within boost namespace to avoid implicitly pulling in boost::swap overloads other than through ADL
+namespace boost_type_traits_swappable_detail
+{
+
+using std::swap;
+
+template<class T, class U, bool B = noexcept(swap(boost::declval<T>(), boost::declval<U>()))> boost::integral_constant<bool, B> is_nothrow_swappable_with_impl( int );
+template<class T, class U> boost::false_type is_nothrow_swappable_with_impl( ... );
+template<class T, class U>
+struct is_nothrow_swappable_with_helper { typedef decltype( boost_type_traits_swappable_detail::is_nothrow_swappable_with_impl<T, U>(0) ) type; };
+
+template<class T, bool B = noexcept(swap(boost::declval<T&>(), boost::declval<T&>()))> boost::integral_constant<bool, B> is_nothrow_swappable_impl( int );
+template<class T> boost::false_type is_nothrow_swappable_impl( ... );
+template<class T>
+struct is_nothrow_swappable_helper { typedef decltype( boost_type_traits_swappable_detail::is_nothrow_swappable_impl<T>(0) ) type; };
+
+} // namespace boost_type_traits_swappable_detail
+
+#endif // #ifndef BOOST_TYPE_TRAITS_DETAIL_IS_SWAPPABLE_CXX_11_HPP_INCLUDED

--- a/include/boost/type_traits/detail/is_swappable_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_swappable_cxx_11.hpp
@@ -2,12 +2,14 @@
 #define BOOST_TYPE_TRAITS_DETAIL_IS_SWAPPABLE_CXX_11_HPP_INCLUDED
 
 //  Copyright 2017 Peter Dimov
+//  Copyright 2023 Andrey Semashev
 //
 //  Distributed under the Boost Software License, Version 1.0.
 //  See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/config.hpp>
+#include <boost/config/workaround.hpp>
 #include <boost/type_traits/declval.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #if __cplusplus >= 201103L || defined(BOOST_DINKUMWARE_STDLIB)
@@ -22,6 +24,18 @@ namespace boost_type_traits_swappable_detail
 
 using std::swap;
 
+template<class T, class U, class = decltype(swap(boost::declval<T>(), boost::declval<U>()))> boost::true_type is_swappable_with_impl( int );
+template<class T, class U> boost::false_type is_swappable_with_impl( ... );
+template<class T, class U>
+struct is_swappable_with_helper { typedef decltype( boost_type_traits_swappable_detail::is_swappable_with_impl<T, U>(0) ) type; };
+
+template<class T, class = decltype(swap(boost::declval<T&>(), boost::declval<T&>()))> boost::true_type is_swappable_impl( int );
+template<class T> boost::false_type is_swappable_impl( ... );
+template<class T>
+struct is_swappable_helper { typedef decltype( boost_type_traits_swappable_detail::is_swappable_impl<T>(0) ) type; };
+
+#if !defined(BOOST_NO_CXX11_NOEXCEPT) && !BOOST_WORKAROUND(BOOST_GCC, < 40700)
+
 template<class T, class U, bool B = noexcept(swap(boost::declval<T>(), boost::declval<U>()))> boost::integral_constant<bool, B> is_nothrow_swappable_with_impl( int );
 template<class T, class U> boost::false_type is_nothrow_swappable_with_impl( ... );
 template<class T, class U>
@@ -31,6 +45,8 @@ template<class T, bool B = noexcept(swap(boost::declval<T&>(), boost::declval<T&
 template<class T> boost::false_type is_nothrow_swappable_impl( ... );
 template<class T>
 struct is_nothrow_swappable_helper { typedef decltype( boost_type_traits_swappable_detail::is_nothrow_swappable_impl<T>(0) ) type; };
+
+#endif // !defined(BOOST_NO_CXX11_NOEXCEPT) && !BOOST_WORKAROUND(BOOST_GCC, < 40700)
 
 } // namespace boost_type_traits_swappable_detail
 

--- a/include/boost/type_traits/detail/is_swappable_cxx_11.hpp
+++ b/include/boost/type_traits/detail/is_swappable_cxx_11.hpp
@@ -34,7 +34,22 @@ template<class T> boost::false_type is_swappable_impl( ... );
 template<class T>
 struct is_swappable_helper { typedef decltype( boost_type_traits_swappable_detail::is_swappable_impl<T>(0) ) type; };
 
-#if !defined(BOOST_NO_CXX11_NOEXCEPT) && !BOOST_WORKAROUND(BOOST_GCC, < 40700)
+#if !defined(BOOST_NO_CXX11_NOEXCEPT)
+
+#if BOOST_WORKAROUND(BOOST_GCC, < 40700)
+
+// gcc 4.6 ICEs when noexcept operator is used on an invalid expression
+template<class T, class U, bool = is_swappable_with_helper<T, U>::type::value>
+struct is_nothrow_swappable_with_helper { typedef boost::false_type type; };
+template<class T, class U>
+struct is_nothrow_swappable_with_helper<T, U, true> { typedef boost::integral_constant<bool, noexcept(swap(boost::declval<T>(), boost::declval<U>()))> type; };
+
+template<class T, bool = is_swappable_helper<T>::type::value>
+struct is_nothrow_swappable_helper { typedef boost::false_type type; };
+template<class T>
+struct is_nothrow_swappable_helper<T, true> { typedef boost::integral_constant<bool, noexcept(swap(boost::declval<T&>(), boost::declval<T&>()))> type; };
+
+#else // BOOST_WORKAROUND(BOOST_GCC, < 40700)
 
 template<class T, class U, bool B = noexcept(swap(boost::declval<T>(), boost::declval<U>()))> boost::integral_constant<bool, B> is_nothrow_swappable_with_impl( int );
 template<class T, class U> boost::false_type is_nothrow_swappable_with_impl( ... );
@@ -46,7 +61,9 @@ template<class T> boost::false_type is_nothrow_swappable_impl( ... );
 template<class T>
 struct is_nothrow_swappable_helper { typedef decltype( boost_type_traits_swappable_detail::is_nothrow_swappable_impl<T>(0) ) type; };
 
-#endif // !defined(BOOST_NO_CXX11_NOEXCEPT) && !BOOST_WORKAROUND(BOOST_GCC, < 40700)
+#endif // BOOST_WORKAROUND(BOOST_GCC, < 40700)
+
+#endif // !defined(BOOST_NO_CXX11_NOEXCEPT)
 
 } // namespace boost_type_traits_swappable_detail
 

--- a/include/boost/type_traits/is_nothrow_swappable.hpp
+++ b/include/boost/type_traits/is_nothrow_swappable.hpp
@@ -8,10 +8,9 @@
 //  http://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/config.hpp>
-#include <boost/config/workaround.hpp>
 
 #if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) \
-   || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) || BOOST_WORKAROUND(BOOST_GCC, < 40700)
+   || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
 
 #include <boost/type_traits/is_scalar.hpp>
 #include <boost/type_traits/is_const.hpp>

--- a/include/boost/type_traits/is_nothrow_swappable.hpp
+++ b/include/boost/type_traits/is_nothrow_swappable.hpp
@@ -28,35 +28,16 @@ template <class T> struct is_nothrow_swappable_with<T, T> : is_nothrow_swappable
 
 #else
 
-#include <boost/type_traits/declval.hpp>
-#include <boost/type_traits/integral_constant.hpp>
-#include <algorithm>
+#include <boost/type_traits/detail/is_swappable_cxx_11.hpp>
 
 namespace boost
 {
 
-namespace type_traits_swappable_detail
-{
-
-using std::swap;
-
-template<class T, class U, bool B = noexcept(swap(declval<T>(), declval<U>()))> integral_constant<bool, B> is_nothrow_swappable_with_impl( int );
-template<class T, class U> false_type is_nothrow_swappable_with_impl( ... );
-template<class T, class U>
-struct is_nothrow_swappable_with_helper { typedef decltype( type_traits_swappable_detail::is_nothrow_swappable_with_impl<T, U>(0) ) type; };
-
-template<class T, bool B = noexcept(swap(declval<T&>(), declval<T&>()))> integral_constant<bool, B> is_nothrow_swappable_impl( int );
-template<class T> false_type is_nothrow_swappable_impl( ... );
-template<class T>
-struct is_nothrow_swappable_helper { typedef decltype( type_traits_swappable_detail::is_nothrow_swappable_impl<T>(0) ) type; };
-
-} // namespace type_traits_swappable_detail
-
-template<class T, class U> struct is_nothrow_swappable_with: type_traits_swappable_detail::is_nothrow_swappable_with_helper<T, U>::type
+template<class T, class U> struct is_nothrow_swappable_with: boost_type_traits_swappable_detail::is_nothrow_swappable_with_helper<T, U>::type
 {
 };
 
-template<class T> struct is_nothrow_swappable: type_traits_swappable_detail::is_nothrow_swappable_helper<T>::type
+template<class T> struct is_nothrow_swappable: boost_type_traits_swappable_detail::is_nothrow_swappable_helper<T>::type
 {
 };
 

--- a/include/boost/type_traits/is_swappable.hpp
+++ b/include/boost/type_traits/is_swappable.hpp
@@ -1,0 +1,92 @@
+#ifndef BOOST_TYPE_TRAITS_IS_SWAPPABLE_HPP_INCLUDED
+#define BOOST_TYPE_TRAITS_IS_SWAPPABLE_HPP_INCLUDED
+
+//  Copyright 2023 Andrey Semashev
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/config.hpp>
+#include <boost/config/workaround.hpp>
+
+#if !defined(BOOST_NO_SFINAE_EXPR) && !defined(BOOST_NO_CXX11_DECLTYPE) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) && \
+    !(defined(BOOST_DINKUMWARE_STDLIB) && (BOOST_CXX_VERSION < 201703L))
+
+#include <boost/type_traits/detail/is_swappable_cxx_11.hpp>
+
+namespace boost
+{
+
+template<class T, class U> struct is_swappable_with : boost_type_traits_swappable_detail::is_swappable_with_helper<T, U>::type
+{
+};
+
+template<class T> struct is_swappable : boost_type_traits_swappable_detail::is_swappable_helper<T>::type
+{
+};
+
+} // namespace boost
+
+#elif defined(BOOST_DINKUMWARE_STDLIB) && (BOOST_CXX_VERSION < 201703L) && \
+    !defined(BOOST_NO_SFINAE_EXPR) && !defined(BOOST_NO_CXX11_DECLTYPE) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800) // these are required for is_constructible and is_assignable
+
+// MSVC standard library has SFINAE-unfriendly std::swap in C++ modes prior to C++17,
+// so we have to reproduce the restrictions on std::swap that are in effect in C++17 mode.
+
+#include <cstddef>
+#include <boost/type_traits/negation.hpp>
+#include <boost/type_traits/conjunction.hpp>
+#include <boost/type_traits/integral_constant.hpp>
+#include <boost/type_traits/is_constructible.hpp>
+#include <boost/type_traits/is_assignable.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/detail/is_swappable_cxx_11.hpp>
+
+namespace boost
+{
+
+template<class T> struct is_swappable
+    : boost::conjunction<
+        boost::negation< boost::is_const<T> >,
+        boost::is_constructible<T, T&&>,
+        boost::is_assignable<T&, T&&>
+    >::type {};
+
+template<> struct is_swappable<void> : false_type {};
+template<> struct is_swappable<const void> : false_type {};
+template<> struct is_swappable<volatile void> : false_type {};
+template<> struct is_swappable<const volatile void> : false_type {};
+template<class T> struct is_swappable<T[]> : false_type {};
+template<class T> struct is_swappable<T(&)[]> : false_type {};
+template<class T, std::size_t N> struct is_swappable<T[N]> : is_swappable<T> {};
+template<class T, std::size_t N> struct is_swappable<T(&)[N]> : is_swappable<T> {};
+
+template<class T, class U> struct is_swappable_with : boost_type_traits_swappable_detail::is_swappable_with_helper<T, U>::type
+{
+};
+
+template<class T> struct is_swappable_with<T, T> : is_swappable<T> {};
+
+} // namespace boost
+
+#else
+
+#include <boost/type_traits/is_scalar.hpp>
+#include <boost/type_traits/integral_constant.hpp>
+
+namespace boost
+{
+
+template<class T> struct is_swappable : boost::is_scalar<T> {};
+template<class T> struct is_swappable<const T> : false_type {};
+
+template<class T, class U> struct is_swappable_with : false_type {};
+template<class T> struct is_swappable_with<T, T> : is_swappable<T> {};
+
+} // namespace boost
+
+#endif
+
+#endif // #ifndef BOOST_TYPE_TRAITS_IS_SWAPPABLE_HPP_INCLUDED

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,21 +1,21 @@
 # copyright John Maddock 2004
-# Use, modification and distribution are subject to the 
-# Boost Software License, Version 1.0. (See accompanying file 
+# Use, modification and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 # bring in the rules for testing
 import testing ;
 import os ;
 
-if [ os.environ CI ] 
+if [ os.environ CI ]
 {
-CI_DEFINES = <define>CI_SUPPRESS_KNOWN_ISSUES=1 ;
+    CI_DEFINES = <define>CI_SUPPRESS_KNOWN_ISSUES=1 ;
 }
 
 
 # type_traits in V1 seem to have two modes: standalone, triggered
 # by a command line option, and a regular. For now, just imitate
-# regular  
+# regular
 
 project : requirements
    # default to all warnings on:
@@ -32,7 +32,7 @@ project : requirements
    <toolset>msvc:<warnings-as-errors>on
    <include>libs/tt2/light/include
    $(CI_DEFINES)
-;             
+;
 
 rule all-tests {
      local result ;
@@ -51,9 +51,9 @@ rule all-tests {
      {
          result += [ run $(source).cpp : : : <define>BOOST_TT_DISABLE_INTRINSICS : $(source)_no_intrinsics ] ;
      }
-     return $(result) ;     
+     return $(result) ;
 }
-            
+
 test-suite type_traits : [ all-tests ] ;
 
 

--- a/test/is_nothrow_swappable_test.cpp
+++ b/test/is_nothrow_swappable_test.cpp
@@ -18,7 +18,6 @@
 
 // These conditions should be similar to those in is_nothrow_swappable.hpp
 #if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) \
-    || BOOST_WORKAROUND(BOOST_GCC, < 40700) \
     || (defined(__GLIBCXX__) && __GLIBCXX__ <= 20120301) // built-in clang++ -std=c++11 on Travis, w/ libstdc++ 4.6
 #define BOOST_TYPE_TRAITS_IS_NOTHROW_SWAPPABLE_EMULATED
 #endif

--- a/test/is_nothrow_swappable_test.cpp
+++ b/test/is_nothrow_swappable_test.cpp
@@ -1,4 +1,3 @@
-
 //  Copyright 2017 Peter Dimov
 //
 //  Distributed under the Boost Software License, Version 1.0.
@@ -16,6 +15,13 @@
 #include "test.hpp"
 #include "check_integral_constant.hpp"
 #include <utility>
+
+// These conditions should be similar to those in is_nothrow_swappable.hpp
+#if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) \
+    || BOOST_WORKAROUND(BOOST_GCC, < 40700) \
+    || (defined(__GLIBCXX__) && __GLIBCXX__ <= 20120301) // built-in clang++ -std=c++11 on Travis, w/ libstdc++ 4.6
+#define BOOST_TYPE_TRAITS_IS_NOTHROW_SWAPPABLE_EMULATED
+#endif
 
 struct X
 {
@@ -45,6 +51,44 @@ struct U
 
 void swap(U&, U&) {}
 
+#if !defined(BOOST_TYPE_TRAITS_IS_NOTHROW_SWAPPABLE_EMULATED) && !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+
+namespace test_ns {
+
+// Not swappable using std::swap, but swappable using test_ns::swap
+struct only_adl_swappable
+{
+    only_adl_swappable(only_adl_swappable const&) = delete;
+    only_adl_swappable& operator= (only_adl_swappable const&) = delete;
+};
+
+inline void swap(only_adl_swappable&, only_adl_swappable&) BOOST_NOEXCEPT {}
+
+} // namespace test_ns
+
+namespace boost {
+namespace type_traits_is_nothrow_swappable_test {
+
+// Some type that is defined within boost namespace and that has a specialized swap overload
+struct swappable
+{
+    swappable(swappable const&) = delete;
+    swappable& operator= (swappable const&) = delete;
+};
+
+// This overload should be selected by is_nothrow_swappable
+inline void swap(swappable&, swappable&) BOOST_NOEXCEPT {}
+
+} // namespace type_traits_is_nothrow_swappable_test
+
+// Some generic swap implementation, such as the one from Boost.Swap. This overload should *not* be selected by is_nothrow_swappable.
+template< typename T1, typename T2 >
+inline void swap(T1&, T2&) {}
+
+} // namespace boost
+
+#endif
+
 TT_TEST_BEGIN(is_nothrow_swappable)
 
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int>::value, true);
@@ -52,9 +96,7 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const>::value, fals
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int volatile>::value, true);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const volatile>::value, false);
 
-#if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) \
-    || BOOST_WORKAROUND(BOOST_GCC, < 40700)\
-    || (defined(__GLIBCXX__) && __GLIBCXX__ <= 20120301) // built-in clang++ -std=c++11 on Travis, w/ libstdc++ 4.6
+#if defined(BOOST_TYPE_TRAITS_IS_NOTHROW_SWAPPABLE_EMULATED)
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int[2]>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int const[2]>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<int volatile[2]>::value, false);
@@ -71,9 +113,7 @@ BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<void const>::value, fal
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<void volatile>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<void const volatile>::value, false);
 
-#if defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) \
-     || BOOST_WORKAROUND(BOOST_GCC, < 40700)\
-    || (defined(__GLIBCXX__) && __GLIBCXX__ <= 20120301) // built-in clang++ -std=c++11 on Travis, w/ libstdc++ 4.6
+#if defined(BOOST_TYPE_TRAITS_IS_NOTHROW_SWAPPABLE_EMULATED)
 
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X>::value, false);
 BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<X const>::value, false);
@@ -156,6 +196,30 @@ BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<V, int> >::v
 BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<V, int> const>::value), false);
 BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<V, int> volatile>::value), false);
 BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_nothrow_swappable<std::pair<V, int> const volatile>::value), false);
+
+#if !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<test_ns::only_adl_swappable>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<test_ns::only_adl_swappable const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<test_ns::only_adl_swappable volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<test_ns::only_adl_swappable const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<test_ns::only_adl_swappable[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<test_ns::only_adl_swappable const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<test_ns::only_adl_swappable volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<test_ns::only_adl_swappable const volatile[2]>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<boost::type_traits_is_nothrow_swappable_test::swappable>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<boost::type_traits_is_nothrow_swappable_test::swappable const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<boost::type_traits_is_nothrow_swappable_test::swappable volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<boost::type_traits_is_nothrow_swappable_test::swappable const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<boost::type_traits_is_nothrow_swappable_test::swappable[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<boost::type_traits_is_nothrow_swappable_test::swappable const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<boost::type_traits_is_nothrow_swappable_test::swappable volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_nothrow_swappable<boost::type_traits_is_nothrow_swappable_test::swappable const volatile[2]>::value, false);
+
+#endif // !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
 
 #endif
 

--- a/test/is_swappable_test.cpp
+++ b/test/is_swappable_test.cpp
@@ -1,0 +1,231 @@
+//  Copyright 2023 Andrey Semashev
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+
+#ifdef TEST_STD
+#  include <type_traits>
+#else
+#  include <boost/type_traits/is_swappable.hpp>
+#endif
+
+#include <boost/config.hpp>
+
+#include "test.hpp"
+#include "check_integral_constant.hpp"
+#include <utility>
+
+// These conditions should be similar to those in is_swappable.hpp
+#if defined(BOOST_DINKUMWARE_STDLIB) && (BOOST_CXX_VERSION < 201703L) && \
+    !defined(BOOST_NO_SFINAE_EXPR) && !defined(BOOST_NO_CXX11_DECLTYPE) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800) // these are required for is_constructible and is_assignable
+#define BOOST_TYPE_TRAITS_IS_SWAPPABLE_MSVC_EMULATED
+#elif defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
+#define BOOST_TYPE_TRAITS_IS_SWAPPABLE_CXX03_EMULATED
+#endif
+
+struct X
+{
+};
+
+struct Y
+{
+    Y( Y const& ) {}
+};
+
+struct Z
+{
+    Z& operator=( Z const& ) { return *this; }
+};
+
+struct U
+{
+};
+
+void swap(U&, U&) {}
+
+#if !defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_CXX03_EMULATED) && !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+
+struct not_swappable
+{
+    not_swappable(not_swappable const&) = delete;
+    not_swappable& operator= (not_swappable const&) = delete;
+};
+
+namespace test_ns {
+
+// Not swappable using std::swap, but swappable using test_ns::swap
+struct only_adl_swappable
+{
+    only_adl_swappable(only_adl_swappable const&) = delete;
+    only_adl_swappable& operator= (only_adl_swappable const&) = delete;
+};
+
+inline void swap(only_adl_swappable&, only_adl_swappable&) BOOST_NOEXCEPT {}
+
+} // namespace test_ns
+
+#endif
+
+TT_TEST_BEGIN(is_swappable)
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int volatile>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int const volatile>::value, false);
+
+#if defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_CXX03_EMULATED)
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int const volatile[2]>::value, false);
+#else
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int volatile[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<int const volatile[2]>::value, false);
+#endif
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<void>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<void const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<void volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<void const volatile>::value, false);
+
+#if defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_CXX03_EMULATED)
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X const volatile[2]>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y const volatile[2]>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z const volatile[2]>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<U>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<U const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<U volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<U const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<X, int> >::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<X, int> const>::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<X, int> volatile>::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<X, int> const volatile>::value), false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<Y, int> >::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<Y, int> const>::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<Y, int> volatile>::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<Y, int> const volatile>::value), false);
+
+#else // defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_CXX03_EMULATED)
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<X const volatile[2]>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Y const volatile[2]>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<Z const volatile[2]>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<U>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<U const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<U volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<U const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<X, int> >::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<X, int> const>::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<X, int> volatile>::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<X, int> const volatile>::value), false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<Y, int> >::value), true);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<Y, int> const>::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<Y, int> volatile>::value), false);
+BOOST_CHECK_INTEGRAL_CONSTANT((::tt::is_swappable<std::pair<Y, int> const volatile>::value), false);
+
+#endif // defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_CXX03_EMULATED)
+
+#if !defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_CXX03_EMULATED) && !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<not_swappable>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<not_swappable const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<not_swappable volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<not_swappable const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<not_swappable[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<not_swappable const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<not_swappable volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<not_swappable const volatile[2]>::value, false);
+
+#if !defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_MSVC_EMULATED)
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable[2]>::value, true);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable const volatile[2]>::value, false);
+
+#else // !defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_MSVC_EMULATED)
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable const>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable volatile>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable const volatile>::value, false);
+
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable const[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable volatile[2]>::value, false);
+BOOST_CHECK_INTEGRAL_CONSTANT(::tt::is_swappable<test_ns::only_adl_swappable const volatile[2]>::value, false);
+
+#endif // !defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_MSVC_EMULATED)
+
+#endif // !defined(BOOST_TYPE_TRAITS_IS_SWAPPABLE_CXX03_EMULATED) && !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+
+TT_TEST_END


### PR DESCRIPTION
This PR adds `is_swappable` trait and makes `is_nothrow_swappable` reuse it to hopefully fix ICEs with gcc 4.6.

Also, `is_(nothrow_)swappable` implementation namespace is now not within `boost` namespace to avoid any `boost::swap` overloads influencing the trait result, unless those overloads are found via ADL. Added tests to verify that ADL for swap overloads works.
