### PR TITLE
Match `std::integral_constant` by adding `operator()` and by marking `operator T` as `noexcept`. Other minor changes.

### DIFF
--- a/include/boost/type_traits/integral_constant.hpp
+++ b/include/boost/type_traits/integral_constant.hpp
@@ -61,7 +61,7 @@ namespace boost{
       {
          static const char data[sizeof(long)] = { 0 };
          static const void* pdata = data;
-         return *(reinterpret_cast<const mpl::integral_c<T, val>*>(pdata));
+         return *static_cast<const mpl::integral_c<T, val>*>(pdata);
       }
       BOOST_CONSTEXPR operator T()const { return val; }
    };
@@ -81,7 +81,7 @@ namespace boost{
       {
          static const char data[sizeof(long)] = { 0 };
          static const void* pdata = data;
-         return *(reinterpret_cast<const mpl::bool_<val>*>(pdata));
+         return *static_cast<const mpl::bool_<val>*>(pdata);
       }
       BOOST_CONSTEXPR operator bool()const { return val; }
    };

--- a/include/boost/type_traits/integral_constant.hpp
+++ b/include/boost/type_traits/integral_constant.hpp
@@ -60,7 +60,7 @@ namespace boost{
       operator const mpl::integral_c<T, val>& ()const
       {
          static const char data[sizeof(long)] = { 0 };
-         static const void* pdata = data;
+         const void* const pdata = data;
          return *static_cast<const mpl::integral_c<T, val>*>(pdata);
       }
       BOOST_CONSTEXPR operator T()const { return val; }
@@ -80,7 +80,7 @@ namespace boost{
       operator const mpl::bool_<val>& ()const
       {
          static const char data[sizeof(long)] = { 0 };
-         static const void* pdata = data;
+         const void* const pdata = data;
          return *static_cast<const mpl::bool_<val>*>(pdata);
       }
       BOOST_CONSTEXPR operator bool()const { return val; }

--- a/include/boost/type_traits/integral_constant.hpp
+++ b/include/boost/type_traits/integral_constant.hpp
@@ -63,7 +63,7 @@ namespace boost{
          const void* const pdata = data;
          return *static_cast<const mpl::integral_c<T, val>*>(pdata);
       }
-      BOOST_CONSTEXPR operator T()const { return val; }
+      BOOST_CONSTEXPR operator T()const BOOST_NOEXCEPT { return val; }
    };
 
    template <class T, T val>
@@ -83,7 +83,7 @@ namespace boost{
          const void* const pdata = data;
          return *static_cast<const mpl::bool_<val>*>(pdata);
       }
-      BOOST_CONSTEXPR operator bool()const { return val; }
+      BOOST_CONSTEXPR operator bool()const BOOST_NOEXCEPT { return val; }
    };
 
    template <bool val>

--- a/include/boost/type_traits/integral_constant.hpp
+++ b/include/boost/type_traits/integral_constant.hpp
@@ -64,6 +64,7 @@ namespace boost{
          return *static_cast<const mpl::integral_c<T, val>*>(pdata);
       }
       BOOST_CONSTEXPR operator T()const BOOST_NOEXCEPT { return val; }
+      BOOST_CONSTEXPR T operator()()const BOOST_NOEXCEPT { return val; }
    };
 
    template <class T, T val>
@@ -84,6 +85,7 @@ namespace boost{
          return *static_cast<const mpl::bool_<val>*>(pdata);
       }
       BOOST_CONSTEXPR operator bool()const BOOST_NOEXCEPT { return val; }
+      BOOST_CONSTEXPR bool operator()()const BOOST_NOEXCEPT { return val; }
    };
 
    template <bool val>

--- a/test/integral_constant_test.cpp
+++ b/test/integral_constant_test.cpp
@@ -1,0 +1,28 @@
+// Copyright 2025 DoctorNoobingstoneIPresume
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/type_traits/integral_constant.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/static_assert.hpp>
+
+int main ()
+{
+    // [2025-01-07] Adapted from example in https://en.cppreference.com/w/cpp/types/integral_constant ...
+
+    using two_t  = boost::integral_constant <int, 2>;
+    using four_t = boost::integral_constant <int, 4>;
+
+    BOOST_STATIC_ASSERT ((! boost::is_same <two_t, four_t>::value));
+    BOOST_STATIC_ASSERT ((two_t::value * 2 == four_t::value));
+    BOOST_STATIC_ASSERT ((two_t () << 1 == four_t ()));
+    BOOST_STATIC_ASSERT ((two_t () () << 1 == four_t () ()));
+
+    enum class E {e0, e1};
+    using c0 = boost::integral_constant <E, E::e0>;
+    using c1 = boost::integral_constant <E, E::e1>;
+    BOOST_STATIC_ASSERT ((c0::value != E::e1));
+    BOOST_STATIC_ASSERT ((c0 () == E::e0));
+    BOOST_STATIC_ASSERT ((boost::is_same <c1, c1>::value));
+}


### PR DESCRIPTION
Conversion between pointers of unrelated types `Source` and `Target` can be done with `static_cast` => IMO should be done with `static_cast` (in order not to give the impression that `reinterpret_cast` really is needed):

  `T *ptr_target = static_cast <T *> (static_cast <void *> (ptr_source));`

IMO `reinterpret_cast` should be used for pointer-to-integral and integral-to-pointer conversions (only).