### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/type_traits

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/type_traits
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,15 +5,17 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/static_assert//boost_static_assert ;
+
 project /boost/type_traits
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/static_assert//boost_static_assert
         <include>include
     ;
 
 explicit
-    [ alias boost_type_traits ]
+    [ alias boost_type_traits : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_type_traits test ]
     # Other Boost lib tests depend on the type_traits test checks.
     [ alias testing
@@ -27,3 +29,4 @@ explicit
 
 call-if : boost-library type_traits
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,29 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/type_traits
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/static_assert//boost_static_assert
+        <include>include
+    ;
+
+explicit
+    [ alias boost_type_traits ]
+    [ alias all : boost_type_traits test ]
+    # Other Boost lib tests depend on the type_traits test checks.
+    [ alias testing
+        : # sources
+        : # requirements
+        : # default-buidl
+        : # usage-requirements
+            <include>test
+        ]
+    ;
+
+call-if : boost-library type_traits
+    ;

--- a/build.jam
+++ b/build.jam
@@ -7,8 +7,8 @@ import project ;
 
 project /boost/type_traits
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/static_assert//boost_static_assert
+        <library>/boost/config//boost_config
+        <library>/boost/static_assert//boost_static_assert
         <include>include
     ;
 

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -18,7 +18,7 @@ boostbook standalone
         # Index generation:
         # Path for links to Boost:
         <xsl:param>boost.root=../../../..
-        
+
         # Some general style settings:
         <xsl:param>table.footnote.number.format=1
         <xsl:param>footnote.number.format=1
@@ -36,7 +36,7 @@ boostbook standalone
         <xsl:param>toc.max.depth=4
         # How far down we go with TOC's
         <xsl:param>generate.section.toc.level=10
-        
+
         # PDF Options:
         # TOC Generation: this is needed for FOP-0.9 and later:
         <xsl:param>fop1.extensions=0
@@ -62,7 +62,7 @@ boostbook standalone
         <format>pdf:<auto-index-internal>off
         <format>html:<auto-index-internal>on
         <auto-index-script>$(here)/index.idx
-        <auto-index-prefix>$(here)/../../.. 
+        <auto-index-prefix>$(here)/../include
         <auto-index>on
     ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,9 +18,9 @@ if [ os.environ CI ]
 # regular
 
 project : requirements
-   <source>/boost/core//boost_core
-   <source>/boost/move//boost_move
-   <source>/boost/mpl//boost_mpl
+   <library>/boost/core//boost_core
+   <library>/boost/move//boost_move
+   <library>/boost/mpl//boost_mpl
 
    # default to all warnings on:
    <warnings>all

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,6 +18,10 @@ if [ os.environ CI ]
 # regular
 
 project : requirements
+   <source>/boost/core//boost_core
+   <source>/boost/move//boost_move
+   <source>/boost/mpl//boost_mpl
+
    # default to all warnings on:
    <warnings>all
    # set warnings as errors for those compilers we know we get warning free:


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.