### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,4 @@ target_include_directories(boost_type_traits INTERFACE include)
 target_link_libraries(boost_type_traits
   INTERFACE
     Boost::config
-    Boost::static_assert
 )

--- a/build.jam
+++ b/build.jam
@@ -7,7 +7,7 @@ require-b2 5.2 ;
 
 constant boost_dependencies :
     /boost/config//boost_config
-    /boost/static_assert//boost_static_assert ;
+    ;
 
 project /boost/type_traits
     : common-requirements


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.