### PR TITLE
Drone: drone.sh

### DIFF
--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -ex
+export TRAVIS_BUILD_DIR=$(pwd)
+export DRONE_BUILD_DIR=$(pwd)
+export TRAVIS_BRANCH=$DRONE_BRANCH
+export VCS_COMMIT_ID=$DRONE_COMMIT
+export GIT_COMMIT=$DRONE_COMMIT
+export REPO_NAME=$DRONE_REPO
+export PATH=~/.local/bin:/usr/local/bin:$PATH
+
+echo '==================================> BEFORE_INSTALL'
+
+. .drone/before-install.sh
+
+echo '==================================> INSTALL'
+
+cd ..
+git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+cd boost-root
+git submodule update --init tools/build
+git submodule update --init libs/config
+git submodule update --init tools/boost_install
+git submodule update --init libs/headers
+git submodule update --init tools/boostdep
+cp -r $TRAVIS_BUILD_DIR/* libs/type_traits
+python tools/boostdep/depinst/depinst.py type_traits
+./bootstrap.sh
+./b2 headers
+
+echo '==================================> BEFORE_SCRIPT'
+
+. $DRONE_BUILD_DIR/.drone/before-script.sh
+
+echo '==================================> SCRIPT'
+
+echo "using $TOOLSET : : $COMPILER ;" > ~/user-config.jam
+IFS=','
+for CXXLOCAL in $CXXSTD; do  (cd libs/config/test && ../../../b2 config_info_travis_install toolset=$TOOLSET cxxstd=$CXXLOCAL $CXXSTD_DIALECT && echo With Standard Version $CXXLOCAL && ./config_info_travis && rm ./config_info_travis)  done
+unset IFS
+./b2 libs/type_traits/test toolset=$TOOLSET cxxstd=$CXXSTD $CXXSTD_DIALECT
+
+echo '==================================> AFTER_SUCCESS'
+
+. $DRONE_BUILD_DIR/.drone/after-success.sh


### PR DESCRIPTION
Most boost drone configurations call the main script `.drone/drone.sh`.   A few of the early deployments used `.drone/boost.sh`.

To enable smart defaults it would be convenient to standardize on a name: `.drone/drone.sh`. 

Multi-step process:

1. Merge this copy of `drone.sh`

2. After 2 weeks, the defaults will change.  In the event you haven't yet merged this PR, drone might stop working, but that can be easily fixed by merging this PR.

3. After 2 months (just to be careful) go ahead and delete your copy of `.drone/boost.sh` .    The relevant file will be  `.drone/drone.sh`.